### PR TITLE
Make language defaults in line with old CMS values

### DIFF
--- a/src/Text.php
+++ b/src/Text.php
@@ -327,18 +327,19 @@ class Text
 	 * Translate a string into the current language and stores it in the JavaScript language store.
 	 *
 	 * @param   string   $string                The Text key.
-	 * @param   array    $jsSafe                Ensure the output is JavaScript safe.
+	 * @param   mixed    $jsSafe                Ensure the output is JavaScript safe. Passing in an array is deprecated from 2.0
 	 * @param   boolean  $interpretBackSlashes  Interpret \t and \n.
 	 *
 	 * @return  array
 	 *
 	 * @since   1.0
 	 */
-	public function script($string = null, $jsSafe = array(), $interpretBackSlashes = true)
+	public function script($string = null, $jsSafe = false, $interpretBackSlashes = true)
 	{
 		// Add the string to the array if not null.
 		if ($string !== null)
 		{
+			// @deprecated Passing in an array for the js parameter is deprecated
 			if (is_array($jsSafe))
 			{
 				if (array_key_exists('interpretBackSlashes', $jsSafe))


### PR DESCRIPTION
This was always false in the CMS ever since the platform project. In the old framework project (https://github.com/joomla/joomla-framework/blob/staging/src/Joomla/Language/Text.php#L340) it was false, however from the first commit of the language package in this github repo it's been an array. I don't know why this is changed in the refactored branch. 

I'm deprecating that functionality as well as it doesn't really seem to give you anything - the only 2 array params that do anything are the params of the function anyhow (note we could port this deprecation back to 1.x branch and remove it in 2.x??)