### PR TITLE
Deprecate support for the _QQ_ quote alias

### DIFF
--- a/src/Language.php
+++ b/src/Language.php
@@ -12,6 +12,8 @@ use Joomla\String\String;
 
 /**
  * Allows for quoting in language .ini files.
+ *
+ * @deprecated  2.0
  */
 define('_QQ_', '"');
 
@@ -829,6 +831,7 @@ class Language
 	 * @return  array  The array of parsed strings.
 	 *
 	 * @since   1.0
+	 * @note    As of 2.0, this method will no longer support parsing _QQ_ into quotes
 	 */
 	protected function parse($filename)
 	{


### PR DESCRIPTION
This PR deprecates support for the `_QQ_` quote alias for the `"` character as it is no longer necessary (this was used primarily while the class supported PHP 5.2).  Plain quotes may be used within HTML strings (such as `JSAMPLE="<span class="example">Sample</span>"` and otherwise should be escaped (`\"`) or HTML entities (`&quot;`).