### PR TITLE
Add check if false is returned

### DIFF
--- a/src/Language.php
+++ b/src/Language.php
@@ -391,6 +391,7 @@ class Language
 	 * @return  string  The transliteration of the string.
 	 *
 	 * @since   1.0
+	 * @throws  \RuntimeException
 	 */
 	public function transliterate($string)
 	{
@@ -400,9 +401,15 @@ class Language
 		}
 
 		$string = Transliterate::utf8_latin_to_ascii($string);
-		$string = String::strtolower($string);
+		$lowercaseString = String::strtolower($string);
 
-		return $string;
+		// String can return false if there isn't a fully valid UTF-8 string entered
+		if ($lowercaseString == false)
+		{
+			throw new \RuntimeException('Invalid UTF-8 was detected in the string "%s"', $lowercaseString);
+		}
+
+		return $lowercaseString;
 	}
 
 	/**


### PR DESCRIPTION
In ```String::strtolower``` if invalid UTF-8 is passed in then it returns false (https://github.com/joomla-framework/string/blob/master/src/phputf8/native/core.php#L419).

Theoretically this shouldn't ever happen as we are enforcing ACII-7 encoding. But scrutinizer and various IDE's throw errors about this. So I've added in a check so that if false is returned a RuntimeException is thrown.

I haven't got a unit test as I dunno how to actually trigger this scenario.