### PR TITLE
Backport proposed LanguageFactory to assist in 1.x -> 2.x transition

### DIFF
--- a/src/Language.php
+++ b/src/Language.php
@@ -29,8 +29,18 @@ class Language
 	 *
 	 * @var    array
 	 * @since  1.0
+	 * @deprecated  2.0
 	 */
 	protected static $languages = array();
+
+	/**
+	 * Cached LanguageFactory object
+	 *
+	 * @var    LanguageFactory
+	 * @since  __DEPLOY_VERSION__
+	 * @deprecated  2.0
+	 */
+	protected static $languageFactory;
 
 	/**
 	 * Debug language, If true, highlights if string isn't found.
@@ -285,27 +295,16 @@ class Language
 	 * @return  Language  The Language object.
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0  Use LanguageFactory::getLanguage() instead
 	 */
 	public static function getInstance($lang = null, $debug = false)
 	{
-		if (!isset(self::$languages[$lang . $debug]))
+		if (!isset(self::$languageFactory))
 		{
-			$language = new self($lang, $debug);
-
-			self::$languages[$lang . $debug] = $language;
-
-			/*
-			 * Check if Language was instantiated with a null $lang param;
-			 * if so, retrieve the language code from the object and store
-			 * the instance with the language code as well
-			 */
-			if (is_null($lang))
-			{
-				self::$languages[$language->getLanguage() . $debug] = $language;
-			}
+			self::$languageFactory = new LanguageFactory;
 		}
 
-		return self::$languages[$lang . $debug];
+		return self::$languageFactory->getLanguage($lang, null, $debug);
 	}
 
 	/**

--- a/src/LanguageFactory.php
+++ b/src/LanguageFactory.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Part of the Joomla Framework Language Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Language;
+
+use Joomla\Language\Localise\En_GBLocalise as DefaultLocalise;
+
+/**
+ * Language package factory
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class LanguageFactory
+{
+	/**
+	 * Application's default language
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $defaultLanguage = 'en-GB';
+
+	/**
+	 * Container with a list of loaded classes grouped by object type
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private static $loadedClasses = array(
+		'language' => array(),
+		'localise' => array(),
+		'stemmer'  => array()
+	);
+
+	/**
+	 * Get the application's default language
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getDefaultLanguage()
+	{
+		return $this->defaultLanguage;
+	}
+
+	/**
+	 * Returns a language object.
+	 *
+	 * @param   string   $lang   The language to use.
+	 * @param   string   $path   The base path to the language folder.  Unused in 1.x, Language uses JPATH_ROOT constant
+	 * @param   boolean  $debug  The debug mode.
+	 *
+	 * @return  Language
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getLanguage($lang = null, $path = null, $debug = false)
+	{
+		$lang = ($lang === null) ? $this->getDefaultLanguage() : $lang;
+
+		if (!isset(self::$loadedClasses['language'][$lang]))
+		{
+			self::$loadedClasses['language'][$lang] = new Language($lang, $debug);
+		}
+
+		return self::$loadedClasses['language'][$lang];
+	}
+
+	/**
+	 * Get the path to the directory containing the application's language folder
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getLanguageDirectory()
+	{
+		return $this->languageDirectory;
+	}
+
+	/**
+	 * Method to get a stemmer, creating it if necessary.
+	 *
+	 * @param   string  $adapter  The type of stemmer to load.
+	 *
+	 * @return  Stemmer
+	 *
+	 * @note    As of 2.0, this method will throw a RuntimeException if objects do not extend the Stemmer class
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException on invalid stemmer
+	 */
+	public function getStemmer($adapter)
+	{
+		// Setup the adapter for the stemmer.
+		$class = '\\Joomla\\Language\\Stemmer\\' . ucfirst(trim($adapter));
+
+		// If we've already found this object, no need to try and find it again
+		if (isset(self::$loadedClasses['stemmer'][$class]))
+		{
+			return self::$loadedClasses['stemmer'][$class];
+		}
+
+		// Check if a stemmer exists for the adapter.
+		if (!class_exists($class))
+		{
+			// Throw invalid adapter exception.
+			throw new \RuntimeException(sprintf('Invalid stemmer type %s', $class));
+		}
+
+		$stemmer = new $class;
+
+		// Store the class name to the cache
+		self::$loadedClasses['stemmer'][$class] = $stemmer;
+
+		return $stemmer;
+	}
+
+	/**
+	 * Set the application's default language
+	 *
+	 * @param   string  $language  Language code for the application's default language
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setDefaultLanguage($language)
+	{
+		$this->defaultLanguage = $language;
+
+		return $this;
+	}
+}

--- a/src/Stemmer.php
+++ b/src/Stemmer.php
@@ -26,10 +26,11 @@ abstract class Stemmer
 	protected $cache = array();
 
 	/**
-	 * JLanguageStemmer instances.
+	 * Stemmer instances.
 	 *
-	 * @var    array
+	 * @var    Stemmer[]
 	 * @since  1.0
+	 * @deprecated  2.0
 	 */
 	protected static $instances = array();
 
@@ -38,32 +39,17 @@ abstract class Stemmer
 	 *
 	 * @param   string  $adapter  The type of stemmer to load.
 	 *
-	 * @return  Stemmer  A JLanguageStemmer instance.
+	 * @return  Stemmer
 	 *
 	 * @since   1.0
+	 * @deprecated  2.0  Use LanguageFactory::getStemmer() instead
 	 * @throws  RuntimeException on invalid stemmer.
 	 */
 	public static function getInstance($adapter)
 	{
-		// Only create one stemmer for each adapter.
-		if (isset(self::$instances[$adapter]))
-		{
-			return self::$instances[$adapter];
-		}
+		$factory = new LanguageFactory;
 
-		// Setup the adapter for the stemmer.
-		$class = '\\Joomla\\Language\\Stemmer\\' . ucfirst(trim($adapter));
-
-		// Check if a stemmer exists for the adapter.
-		if (!class_exists($class))
-		{
-			// Throw invalid adapter exception.
-			throw new RuntimeException(sprintf('Invalid stemmer type %s', $adapter));
-		}
-
-		self::$instances[$adapter] = new $class;
-
-		return self::$instances[$adapter];
+		return $factory->getStemmer($adapter);
 	}
 
 	/**


### PR DESCRIPTION
This is a partial backport of the factory object in #21 to help with transitioning between 1.x and 2.x releases.  This also adds deprecation notices for features replaced by the factory.