### PR TITLE
Deprecate support for the JavaScript language store

### DIFF
--- a/src/Text.php
+++ b/src/Text.php
@@ -18,8 +18,9 @@ class Text
 	/**
 	 * javascript strings
 	 *
-	 * @var    array
-	 * @since  1.0
+	 * @var         array
+	 * @since       1.0
+	 * @deprecated  2.0
 	 */
 	protected static $strings = array();
 
@@ -71,7 +72,7 @@ class Text
 	 * @param   string   $string                The string to translate.
 	 * @param   mixed    $jsSafe                Boolean: Make the result javascript safe.
 	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
-	 * @param   boolean  $script                To indicate that the string will be push in the javascript language store
+	 * @param   boolean  $script                To indicate that the string will be push in the javascript language store [@deprecated 2.0]
 	 *
 	 * @return  string  The translated string or the key is $script is true
 	 *
@@ -126,7 +127,7 @@ class Text
 	 * @param   string   $alt                   The alternate option for global string
 	 * @param   mixed    $jsSafe                Boolean: Make the result javascript safe.
 	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
-	 * @param   boolean  $script                To indicate that the string will be pushed in the javascript language store
+	 * @param   boolean  $script                To indicate that the string will be pushed in the javascript language store [@deprecated 2.0]
 	 *
 	 * @return  string  The translated string or the key if $script is true
 	 *
@@ -331,7 +332,8 @@ class Text
 	 *
 	 * @return  string
 	 *
-	 * @since   1.0
+	 * @since       1.0
+	 * @deprecated  2.0  Deprecated without replacement
 	 */
 	public static function script($string = null, $jsSafe = false, $interpretBackSlashes = true)
 	{


### PR DESCRIPTION
This PR proposes to deprecate support for the JavaScript language store in the Text class.  I feel this is an application specific feature that should be implemented in downstream uses as needed.

Note this does not remove support for making strings JavaScript safe.