### PR TITLE
Add support for named parameters

### DIFF
--- a/docs/classes/Text.md
+++ b/docs/classes/Text.md
@@ -56,9 +56,8 @@ translation and also has several optional parameters.
  * @param   string   $string                The string to translate.
  * @param   array    $jsSafe                Array containing data to make the string safe for JavaScript output
  * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
- * @param   boolean  $script                To indicate that the string will be push in the javascript language store
  */
-public function translate($string, $jsSafe = array(), $interpretBackSlashes = true, $script = false)
+public function translate($string, $jsSafe = array(), $interpretBackSlashes = true)
 ```
 
 The following example demonstrates basic usage of the `Text` class.
@@ -76,21 +75,6 @@ $translatedString = $text->translate('MY_KEY');
 If the supplied key is found in the `Language` class storage, the translated string will be returned; otherwise the
 key will be returned.
 
-The following example demonstrates storing a language key to the JavaScript store (useful if creating a JavaScript
-API to process translations):
-
-```php
-use Joomla\Language\Language;
-use Joomla\Language\Text;
-
-$language = new Language('/var/www/jfw-application', 'en-GB');
-$text     = new Text($language);
-
-$text->translate('MY_KEY', array('jsSafe' => true), true, true);
-```
-
-In this instance, the language key will always be returned when instructed to store to the JavaScript store.
-
 ### Alternate Translations
 
 The `alt` method is used for creating potential alternate translations of a base language key by specifying a possible
@@ -103,9 +87,8 @@ is returned, otherwise the base language key will be processed for translation.
  * @param   string   $alt                   The alternate option for global string
  * @param   array    $jsSafe                Array containing data to make the string safe for JavaScript output
  * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
- * @param   boolean  $script                To indicate that the string will be push in the javascript language store
  */
-public function alt($string, $alt, $jsSafe = false, $interpretBackSlashes = true, $script = false)
+public function alt($string, $alt, $jsSafe = false, $interpretBackSlashes = true)
 ```
 
 Assuming the following is the contents of the `en-GB.ini` language file:

--- a/docs/classes/Text.md
+++ b/docs/classes/Text.md
@@ -54,10 +54,11 @@ translation and also has several optional parameters.
 ```php
 /*
  * @param   string   $string                The string to translate.
+ * @param   array    $parameters            Array of parameters for the string
  * @param   array    $jsSafe                Array containing data to make the string safe for JavaScript output
  * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
  */
-public function translate($string, $jsSafe = array(), $interpretBackSlashes = true)
+public function translate($string, $parameters = array(), $jsSafe = array(), $interpretBackSlashes = true)
 ```
 
 The following example demonstrates basic usage of the `Text` class.
@@ -75,6 +76,31 @@ $translatedString = $text->translate('MY_KEY');
 If the supplied key is found in the `Language` class storage, the translated string will be returned; otherwise the
 key will be returned.
 
+#### Named Parameter Support
+
+A new feature in 2.0 is support for named parameters.  The second parameter in the `translate` method accepts an
+associative array where the key is the string to replace and the value is the replacement.
+
+Assuming the following is the contents of the `en-GB.ini` language file:
+
+```ini
+MY_KEY="%term% Rocks!"
+```
+
+The following example demonstrates usage of the `translate` method with named parameters.
+
+```php
+use Joomla\Language\Language;
+use Joomla\Language\Text;
+
+$language = new Language('/var/www/jfw-application', 'en-GB');
+$text     = new Text($language);
+
+// Will return "Joomla Rocks!"
+$translatedAltString = $text->translate('MY_KEY', array('%term%' => 'Joomla');
+```
+
+
 ### Alternate Translations
 
 The `alt` method is used for creating potential alternate translations of a base language key by specifying a possible
@@ -85,10 +111,11 @@ is returned, otherwise the base language key will be processed for translation.
 /*
  * @param   string   $string                The string to translate.
  * @param   string   $alt                   The alternate option for global string
+ * @param   array    $parameters            Array of parameters for the string
  * @param   array    $jsSafe                Array containing data to make the string safe for JavaScript output
  * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
  */
-public function alt($string, $alt, $jsSafe = false, $interpretBackSlashes = true)
+public function alt($string, $parameters = array(), $alt, $jsSafe = false, $interpretBackSlashes = true)
 ```
 
 Assuming the following is the contents of the `en-GB.ini` language file:
@@ -113,3 +140,5 @@ $translatedAltString = $text->alt('MY_KEY', 'ROCKS');
 // Will return "Foo"
 $translatedBaseString = $text->alt('MY_KEY', 'IS_COOL');
 ```
+
+The `alt` method also supports named parameters.

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -38,6 +38,12 @@ instead.
 
 The `getInstance()` method in `Stemmer` has been removed.  Use `LanguageFactory::getStemmer()` instead.
 
+### Text::alt() signature changed
+
+The `alt()` method's signature has had a backward compatibility breaking change.  A `$parameters` parameter has been added and is
+now the third parameter in the method signature.  This affects calls to the method which included the `$jsSafe` and
+`$interpretBackSlashes` parameters.
+
 ### Text::script() removed
 
 The `script()` method in `Text` has been removed, as well as support for the internal JavaScript store.  Downstream applications

--- a/src/Text.php
+++ b/src/Text.php
@@ -158,13 +158,12 @@ class Text
 	 *
 	 * The last argument can take an array of options:
 	 *
-	 * array('jsSafe'=>boolean, 'interpretBackSlashes'=>boolean, 'script'=>boolean)
+	 * array('jsSafe'=>boolean, 'interpretBackSlashes'=>boolean)
 	 *
 	 * where:
 	 *
 	 * jsSafe is a boolean to generate a javascript safe strings.
 	 * interpretBackSlashes is a boolean to interpret backslashes \\->\, \n->new line, \t->tabulation.
-	 * script is a boolean to indicate that the string will be push in the javascript language store.
 	 *
 	 * @param   string   $string  The format string.
 	 * @param   integer  $n       The number of items
@@ -222,13 +221,12 @@ class Text
 	 *
 	 * The last argument can take an array of options:
 	 *
-	 * array('jsSafe'=>boolean, 'interpretBackSlashes'=>boolean, 'script'=>boolean)
+	 * array('jsSafe'=>boolean, 'interpretBackSlashes'=>boolean)
 	 *
 	 * where:
 	 *
 	 * jsSafe is a boolean to generate a javascript safe strings.
 	 * interpretBackSlashes is a boolean to interpret backslashes \\->\, \n->new line, \t->tabulation.
-	 * script is a boolean to indicate that the string will be push in the javascript language store.
 	 *
 	 * @param   string  $string  The format string.
 	 *
@@ -263,13 +261,12 @@ class Text
 	 *
 	 * The last argument can take an array of options:
 	 *
-	 * array('jsSafe'=>boolean, 'interpretBackSlashes'=>boolean, 'script'=>boolean)
+	 * array('jsSafe'=>boolean, 'interpretBackSlashes'=>boolean)
 	 *
 	 * where:
 	 *
 	 * jsSafe is a boolean to generate a javascript safe strings.
 	 * interpretBackSlashes is a boolean to interpret backslashes \\->\, \n->new line, \t->tabulation.
-	 * script is a boolean to indicate that the string will be push in the javascript language store.
 	 *
 	 * @param   string  $string  The format string.
 	 *

--- a/src/Text.php
+++ b/src/Text.php
@@ -82,13 +82,14 @@ class Text
 		$factory = new LanguageFactory;
 		$text    = $factory->getText();
 
-		return $text->translate($string, $jsSafe, $interpretBackSlashes);
+		return $text->translate($string, array(), $jsSafe, $interpretBackSlashes);
 	}
 
 	/**
 	 * Translates a string into the current language.
 	 *
 	 * @param   string   $string                The string to translate.
+	 * @param   array    $parameters            Array of parameters for the string
 	 * @param   array    $jsSafe                Array containing data to make the string safe for JavaScript output
 	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
 	 *
@@ -96,7 +97,7 @@ class Text
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function translate($string, $jsSafe = array(), $interpretBackSlashes = true)
+	public function translate($string, $parameters = array(), $jsSafe = array(), $interpretBackSlashes = true)
 	{
 		$lang = $this->getLanguage();
 
@@ -117,7 +118,14 @@ class Text
 			}
 		}
 
-		return $lang->translate($string, $jsSafe, $interpretBackSlashes);
+		$translated = $lang->translate($string, $jsSafe, $interpretBackSlashes);
+
+		if (!empty($parameters))
+		{
+			$translated = strtr($translated, $parameters);
+		}
+
+		return $translated;
 	}
 
 	/**
@@ -125,6 +133,7 @@ class Text
 	 *
 	 * @param   string   $string                The string to translate.
 	 * @param   string   $alt                   The alternate option for global string
+	 * @param   array    $parameters            Array of parameters for the string
 	 * @param   mixed    $jsSafe                Boolean: Make the result javascript safe.
 	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
 	 *
@@ -132,16 +141,16 @@ class Text
 	 *
 	 * @since   1.0
 	 */
-	public function alt($string, $alt, $jsSafe = false, $interpretBackSlashes = true)
+	public function alt($string, $alt, $parameters = array(), $jsSafe = false, $interpretBackSlashes = true)
 	{
 		$lang = $this->getLanguage();
 
 		if ($lang->hasKey($string . '_' . $alt))
 		{
-			return $this->translate($string . '_' . $alt, $jsSafe, $interpretBackSlashes);
+			return $this->translate($string . '_' . $alt, $parameters, $jsSafe, $interpretBackSlashes);
 		}
 
-		return $this->translate($string, $jsSafe, $interpretBackSlashes);
+		return $this->translate($string, $parameters, $jsSafe, $interpretBackSlashes);
 	}
 
 	/**

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -6,6 +6,7 @@
 
 namespace Joomla\Language\Tests;
 
+use Joomla\Language\LanguageFactory;
 use Joomla\Language\Text;
 use Joomla\Language\Language;
 use Joomla\Test\TestHelper;
@@ -15,6 +16,13 @@ use Joomla\Test\TestHelper;
  */
 class TextTest extends \PHPUnit_Framework_TestCase
 {
+	/**
+	 * LanguageFactory object to use for testing
+	 *
+	 * @var  LanguageFactory
+	 */
+	private static $factory;
+
 	/**
 	 * Test Text object
 	 *
@@ -27,7 +35,18 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @var  string
 	 */
-	private $testPath;
+	private static $testPath;
+
+	/**
+	 * This method is called before the first test of this test class is run.
+	 */
+	public static function setUpBeforeClass()
+	{
+		self::$testPath = __DIR__ . '/data';
+
+		self::$factory = new LanguageFactory;
+		self::$factory->setLanguageDirectory(self::$testPath);
+	}
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -37,9 +56,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	{
 		parent::setUp();
 
-		$this->testPath = __DIR__ . '/data';
-
-		$language = new Language($this->testPath, 'en-GB');
+		$language = new Language(self::$testPath, 'en-GB');
 		$language->load();
 		$this->object = new Text($language);
 	}
@@ -54,7 +71,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testVerifyThatTextIsInstantiatedCorrectly()
 	{
-		$this->assertInstanceOf('Joomla\\Language\\Text', new Text(new Language($this->testPath)));
+		$this->assertInstanceOf('Joomla\\Language\\Text', new Text(new Language(self::$testPath)));
 	}
 
 	/**
@@ -80,7 +97,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testVerifyThatSetLanguageReturnsSelf()
 	{
-		$this->assertSame($this->object, $this->object->setLanguage(new Language($this->testPath, 'de-DE')));
+		$this->assertSame($this->object, $this->object->setLanguage(new Language(self::$testPath, 'de-DE')));
 	}
 
 	/**
@@ -125,6 +142,19 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * @testdox  Verify that Text::translate() returns the correct string for a key with named parameters
+	 *
+	 * @covers   Joomla\Language\Text::translate
+	 * @uses     Joomla\Language\Language
+	 * @uses     Joomla\Language\LanguageHelper
+	 * @uses     Joomla\Language\Text
+	 */
+	public function testTranslateReturnsTheCorrectStringForAKeyWithNamedParameters()
+	{
+		$this->assertSame('Bar None', $this->object->translate('Bar %value%', array('%value%' => 'None')));
+	}
+
+	/**
 	 * @testdox  Verify that Text::translate() returns a JavaScript safe string
 	 *
 	 * @covers   Joomla\Language\Text::translate
@@ -134,7 +164,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testTranslateReturnsAJavascriptSafeKey()
 	{
-		$this->assertSame('foobar\\\'s', $this->object->translate('foobar\'s', array('jsSafe' => true)));
+		$this->assertSame('foobar\\\'s', $this->object->translate('foobar\'s', array(), array('jsSafe' => true)));
 	}
 
 	/**
@@ -149,7 +179,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	{
 		$this->assertSame(
 			'foobar\'s',
-			$this->object->translate('foobar\'s', array('interpretBackSlashes' => false), true)
+			$this->object->translate('foobar\'s', array(), array('interpretBackSlashes' => false), true)
 		);
 	}
 
@@ -177,6 +207,19 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	public function testAltReturnsTheCorrectStringForAKeyWithAlt()
 	{
 		$this->assertSame('Car', $this->object->alt('FOO', 'GOO'));
+	}
+
+	/**
+	 * @testdox  Verify that Text::alt() returns the correct string for a key with an alt and named parameters
+	 *
+	 * @covers   Joomla\Language\Text::alt
+	 * @uses     Joomla\Language\Language
+	 * @uses     Joomla\Language\LanguageHelper
+	 * @uses     Joomla\Language\Text
+	 */
+	public function testAltReturnsTheCorrectStringForAKeyWithAltAndNamedParameters()
+	{
+		$this->assertSame('Green Car', $this->object->alt('FOO', 'BOO', array('%description%' => 'Green')));
 	}
 
 	/**

--- a/tests/data/language/en-GB/en-GB.ini
+++ b/tests/data/language/en-GB/en-GB.ini
@@ -1,4 +1,5 @@
 FOO="Bar"
 FOO_GOO="Car"
+FOO_BOO="%description% Car"
 BAR_MORE="%s Bars"
 MANY_CARS="I have %s cars!"


### PR DESCRIPTION
This PR introduces support for named parameters in the `translate()` and `alt()` methods and serves as a potential replacement for sprintf support.

This enables users to create language strings using replaceable parameters such as `MY_KEY="%term% Rocks!"`.  Calls to `Text::translate()` using the named parameter would replace the parameter with a specified value, i.e. `$text->translate('MY_KEY', array('%term%' => 'Joomla');` will result in `Joomla Rocks!`.