### PR TITLE
Remove support for jsSafe param as an array

### DIFF
--- a/src/Text.php
+++ b/src/Text.php
@@ -82,25 +82,7 @@ class Text
 		$factory = new LanguageFactory;
 		$text    = $factory->getText();
 
-		return $text->translate($string, $jsSafe, $interpretBackSlashes);
-	}
-
-	/**
-	 * Translates a string into the current language.
-	 *
-	 * @param   string   $string                The string to translate.
-	 * @param   array    $jsSafe                Array containing data to make the string safe for JavaScript output
-	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
-	 *
-	 * @return  string  The translated string or the key if $script is true
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function translate($string, $jsSafe = array(), $interpretBackSlashes = true)
-	{
-		$lang = $this->getLanguage();
-
-		if (!empty($jsSafe))
+		if (is_array($jsSafe) && !empty($jsSafe))
 		{
 			if (array_key_exists('interpretBackSlashes', $jsSafe))
 			{
@@ -117,7 +99,23 @@ class Text
 			}
 		}
 
-		return $lang->translate($string, $jsSafe, $interpretBackSlashes);
+		return $text->translate($string, $jsSafe, $interpretBackSlashes);
+	}
+
+	/**
+	 * Translates a string into the current language.
+	 *
+	 * @param   string   $string                The string to translate.
+	 * @param   boolean  $jsSafe                True to escape the string for JavaScript output
+	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
+	 *
+	 * @return  string  The translated string or the key if $script is true
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function translate($string, $jsSafe = false, $interpretBackSlashes = true)
+	{
+		return $this->getLanguage()->translate($string, $jsSafe, $interpretBackSlashes);
 	}
 
 	/**

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -134,23 +134,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
 	 */
 	public function testTranslateReturnsAJavascriptSafeKey()
 	{
-		$this->assertSame('foobar\\\'s', $this->object->translate('foobar\'s', array('jsSafe' => true)));
-	}
-
-	/**
-	 * @testdox  Verify that Text::translate() returns the translated string when the input params are overridden
-	 *
-	 * @covers   Joomla\Language\Text::translate
-	 * @uses     Joomla\Language\Language
-	 * @uses     Joomla\Language\LanguageHelper
-	 * @uses     Joomla\Language\Text
-	 */
-	public function testTranslateReturnsTheTranslatedStringWhenTheInputParamsAreOverridden()
-	{
-		$this->assertSame(
-			'foobar\'s',
-			$this->object->translate('foobar\'s', array('interpretBackSlashes' => false), true)
-		);
+		$this->assertSame('foobar\\\'s', $this->object->translate('foobar\'s', true));
 	}
 
 	/**


### PR DESCRIPTION
The `translate` method has internal support for the `$jsSafe` parameter as either an array or boolean.  This PR strips that support out and forces it to always be a boolean.

The `_` proxy method retains support for the array syntax.