### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/LanguageTest.php
+++ b/Tests/LanguageTest.php
@@ -1239,21 +1239,21 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Test...
 	 *
-	 * @covers  Joomla\Language\Language::isRTL
+	 * @covers  Joomla\Language\Language::isRtl
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function testIsRTL()
+	public function testisRtl()
 	{
 		$this->assertFalse(
-			$this->object->isRTL()
+			$this->object->isRtl()
 		);
 
 		TestHelper::setValue($this->object, 'metadata', array('rtl' => true));
 		$this->assertTrue(
-			$this->object->isRTL()
+			$this->object->isRtl()
 		);
 	}
 
@@ -1642,13 +1642,13 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Test...
 	 *
-	 * @covers  Joomla\Language\Language::parseXMLLanguageFile
+	 * @covers  Joomla\Language\Language::parseXmlLanguageFile
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function testParseXMLLanguageFile()
+	public function testParseXmlLanguageFile()
 	{
 		$option = array(
 			'name' => 'English (United Kingdom)',
@@ -1662,14 +1662,14 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals(
 			$option,
-			Language::parseXMLLanguageFile($path),
+			Language::parseXmlLanguageFile($path),
 			'Line: ' . __LINE__
 		);
 
 		$path2 = __DIR__ . '/data/language/es-ES/es-ES.xml';
 		$this->assertEquals(
 			$option,
-			Language::parseXMLLanguageFile($path),
+			Language::parseXmlLanguageFile($path),
 			'Line: ' . __LINE__
 		);
 	}
@@ -1677,17 +1677,17 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Test...
 	 *
-	 * @covers  Joomla\Language\Language::parseXMLLanguageFile
+	 * @covers  Joomla\Language\Language::parseXmlLanguageFile
 	 * @expectedException  RuntimeException
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
 	 */
-	public function testParseXMLLanguageFileException()
+	public function testParseXmlLanguageFileException()
 	{
 		$path = __DIR__ . '/data/language/es-ES/es-ES.xml';
 
-		Language::parseXMLLanguageFile($path);
+		Language::parseXmlLanguageFile($path);
 	}
 }

--- a/src/Language.php
+++ b/src/Language.php
@@ -1093,7 +1093,7 @@ class Language
 	 *
 	 * @since   1.0
 	 */
-	public function isRTL()
+	public function isRtl()
 	{
 		return (bool) $this->metadata['rtl'];
 	}
@@ -1216,7 +1216,7 @@ class Language
 
 		if (is_file("$path/$file"))
 		{
-			$result = self::parseXMLLanguageFile("$path/$file");
+			$result = self::parseXmlLanguageFile("$path/$file");
 		}
 
 		if (empty($result))
@@ -1364,7 +1364,7 @@ class Language
 
 			try
 			{
-				$metadata = self::parseXMLLanguageFile($file->getRealPath());
+				$metadata = self::parseXmlLanguageFile($file->getRealPath());
 
 				if ($metadata)
 				{
@@ -1392,7 +1392,7 @@ class Language
 	 * @since   1.0
 	 * @throws  \RuntimeException
 	 */
-	public static function parseXMLLanguageFile($path)
+	public static function parseXmlLanguageFile($path)
 	{
 		if (!is_readable($path))
 		{


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.