### PR TITLE
[2.0] Create a separate message catalogue for handling translation strings

### DIFF
--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -36,6 +36,11 @@ The `getInstance()` method in `Language` has been removed.  Use `LanguageFactory
 The `setLanguage()` method in `Language` has been removed.  A new Language instance in the new language should be instantiated
 instead.
 
+### Language::$strings removed
+
+The `$strings` class member variable in `Language` has been removed.  Loaded translation strings are now stored in a `MessageCatalogue`
+instance.
+
 ### Abstract Stemmer removed
 
 The abstract `Stemmer` class has been removed. Stemmers are now defined by a new `StemmerInterface`. Use `LanguageFactory::getStemmer()`
@@ -70,3 +75,8 @@ version 1 however could optionally could have callback functions set if such a f
 
 Localise files now MUST implement the LocaliseInterface to be recognised. An base class is available and is suitable for
 many Western Languages.
+
+### Message Key Normalisation
+In 1.x, when retrieving translation strings from the internal store, the key was normalled to full uppercase when loaded, blocking
+use of mixed case strings. In 2.0, keys are normalised to uppercase both when messages are written to a catalogue and when read out
+of the catalogue. If desired, a catalogue allowing mixed case strings can be created by subclassing the `MessageCatalogue` class.

--- a/src/Language.php
+++ b/src/Language.php
@@ -80,14 +80,6 @@ class Language
 	protected $errorfiles = array();
 
 	/**
-	 * Translations
-	 *
-	 * @var    array
-	 * @since  1.0
-	 */
-	protected $strings = array();
-
-	/**
 	 * An array of used text, used during debugging.
 	 *
 	 * @var    array
@@ -136,6 +128,14 @@ class Language
 	protected $basePath;
 
 	/**
+	 * MessageCatalogue object
+	 *
+	 * @var    MessageCatalogue
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $catalogue;
+
+	/**
 	 * Constructor activating the default information of the language.
 	 *
 	 * @param   string   $path   The base path to the language folder
@@ -179,6 +179,8 @@ class Language
 
 		// Grab a localisation file
 		$this->localise = (new LanguageFactory)->getLocalise($lang, $path);
+
+		$this->catalogue = new MessageCatalogue($this->lang);
 
 		$this->load();
 	}
@@ -235,9 +237,9 @@ class Language
 
 		$key = strtoupper($string);
 
-		if (isset($this->strings[$key]))
+		if ($this->catalogue->hasMessage($key))
 		{
-			$string = $this->debug ? '**' . $this->strings[$key] . '**' : $this->strings[$key];
+			$string = $this->debug ? '**' . $this->catalogue->getMessage($key) . '**' : $this->catalogue->getMessage($key);
 
 			// Store debug information
 			if ($this->debug)
@@ -437,8 +439,8 @@ class Language
 		{
 			if (is_array($strings) && count($strings))
 			{
-				$this->strings = array_replace($this->strings, $strings, $this->override);
-				$result        = true;
+				$this->catalogue->addMessages(array_replace($strings, $this->override));
+				$result = true;
 			}
 		}
 
@@ -819,9 +821,7 @@ class Language
 	 */
 	public function hasKey($string)
 	{
-		$key = strtoupper($string);
-
-		return isset($this->strings[$key]);
+		return $this->catalogue->hasMessage($string);
 	}
 
 	/**
@@ -911,6 +911,18 @@ class Language
 	public function getLanguage()
 	{
 		return $this->lang;
+	}
+
+	/**
+	 * Get the message catalogue for the language.
+	 *
+	 * @return  MessageCatalogue
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getCatalogue(): MessageCatalogue
+	{
+		return $this->catalogue;
 	}
 
 	/**

--- a/src/MessageCatalogue.php
+++ b/src/MessageCatalogue.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Part of the Joomla Framework Language Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Language;
+
+/**
+ * Catalogue of loaded translation strings for a language
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class MessageCatalogue
+{
+	/**
+	 * A fallback for this catalogue
+	 *
+	 * @var    MessageCatalogue
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $fallbackCatalogue;
+
+	/**
+	 * The language of the messages in this catalogue
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $language;
+
+	/**
+	 * The messages stored to this catalogue
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $messages = [];
+
+	/**
+	 * MessageCatalogue constructor.
+	 *
+	 * @param   string  $language  The language of the messages in this catalogue
+	 * @param   array   $messages  The messages to seed this catalogue with
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(string $language, array $messages = [])
+	{
+		$this->language = $language;
+
+		$this->addMessages($messages);
+	}
+
+	/**
+	 * Add a message to the catalogue, replacing the key if it already exists
+	 *
+	 * @param   string  $key      The key identifying the message
+	 * @param   string  $message  The message for this key
+	 *
+	 * @return  void
+	 */
+	public function addMessage(string $key, string $message)
+	{
+		$this->addMessages([$key => $message]);
+	}
+
+	/**
+	 * Add messages to the catalogue, replacing any keys which already exist
+	 *
+	 * @param   array  $messages  An associative array containing the messages to add to the catalogue
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addMessages(array $messages)
+	{
+		$this->messages = array_replace($this->messages, array_change_key_case($messages, CASE_UPPER));
+	}
+
+	/**
+	 * Check if this catalogue has a message for the given key, ignoring a fallback if defined
+	 *
+	 * @param   string  $key  The key to check
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function definesMessage(string $key): bool
+	{
+		return isset($this->messages[strtoupper($key)]);
+	}
+
+	/**
+	 * Get the fallback for this catalogue if set
+	 *
+	 * @return  MessageCatalogue|null
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getFallbackCatalogue(): string
+	{
+		return $this->fallbackCatalogue;
+	}
+
+	/**
+	 * Get the language for this catalogue
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getLanguage(): string
+	{
+		return $this->language;
+	}
+
+	/**
+	 * Get the message for a given key
+	 *
+	 * @param   string  $key  The key to get the message for
+	 *
+	 * @return  string  The message if one is set otherwise the key
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMessage(string $key): string
+	{
+		if ($this->definesMessage($key))
+		{
+			return $this->messages[strtoupper($key)];
+		}
+
+		if ($this->fallbackCatalogue)
+		{
+			return $this->fallbackCatalogue->getMessage($key);
+		}
+
+		return strtoupper($key);
+	}
+
+	/**
+	 * Fetch the messages stored in this catalogue
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getMessages(): array
+	{
+		return $this->messages;
+	}
+
+	/**
+	 * Check if the catalogue has a message for the given key
+	 *
+	 * @param   string  $key  The key to check
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function hasMessage(string $key): bool
+	{
+		if ($this->definesMessage($key))
+		{
+			return true;
+		}
+
+		if ($this->fallbackCatalogue)
+		{
+			return $this->fallbackCatalogue->hasMessage($key);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Merge another catalogue into this one
+	 *
+	 * @param   MessageCatalogue  $messageCatalogue  The catalogue to merge
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \LogicException
+	 */
+	public function mergeCatalogue(MessageCatalogue $messageCatalogue)
+	{
+		if ($messageCatalogue->getLanguage() !== $this->getLanguage())
+		{
+			throw new \LogicException('Cannot merge a catalogue that does not have the same language code.');
+		}
+
+		$this->addMessages($messageCatalogue->getMessages());
+	}
+
+	/**
+	 * Set the fallback for this catalogue
+	 *
+	 * @param   MessageCatalogue  $messageCatalogue  The catalogue to use as the fallback
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setFallbackCatalogue(MessageCatalogue $messageCatalogue)
+	{
+		$this->fallbackCatalogue = $messageCatalogue;
+	}
+}

--- a/tests/LanguageTest.php
+++ b/tests/LanguageTest.php
@@ -698,8 +698,8 @@ class LanguageTest extends TestCase
 	 */
 	public function test_WithLoadedStringsAndDebug()
 	{
-		// Loading some strings.
-		TestHelper::setValue($this->object, 'strings', array('DEL' => 'Delete'));
+		$catalogue = TestHelper::getValue($this->object, 'catalogue');
+		$catalogue->addMessage('DEL', 'Delete');
 
 		$this->assertEquals(
 			"Delete",

--- a/tests/MessageCatalogueTest.php
+++ b/tests/MessageCatalogueTest.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * @copyright  Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Language\Tests;
+
+use Joomla\Language\MessageCatalogue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for Joomla\Language\MessageCatalogue.
+ */
+class MessageCatalogueTest extends TestCase
+{
+	/**
+	 * Test message catalogue
+	 *
+	 * @var  MessageCatalogue
+	 */
+	protected $object;
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->object = new MessageCatalogue('en-GB');
+	}
+
+	/**
+	 * @testdox  Verify the catalogue's language is returned
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::getLanguage
+	 */
+	public function testTheCataloguesLanguageIsReturned()
+	{
+		$this->assertSame('en-GB', $this->object->getLanguage());
+	}
+
+	/**
+	 * @testdox  Verify that a single message is added to the catalogue
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 */
+	public function testASingleMessageIsAddedToTheCatalogue()
+	{
+		$this->object->addMessage('foo', 'bar');
+
+		$this->assertAttributeSame(['FOO' => 'bar'], 'messages', $this->object);
+	}
+
+	/**
+	 * @testdox  Verify that multiple messages are added to the catalogue
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::addMessages
+	 */
+	public function testMultipleMessagesAreAddedToTheCatalogue()
+	{
+		$messages = [
+			'foo' => 'bar',
+			'goo' => 'car',
+		];
+
+		$this->object->addMessages($messages);
+
+		$this->assertAttributeSame(array_change_key_case($messages, CASE_UPPER), 'messages', $this->object);
+	}
+
+	/**
+	 * @testdox  Verify that the catalogue accurately reports key presence on this catalogue
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::definesMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 */
+	public function testTheCatalogueAccuratelyReportsKeyPresenceOnThisCatalogue()
+	{
+		$this->object->addMessage('foo', 'bar');
+
+		$fallbackCatalogue = new MessageCatalogue('en-US', ['goo' => 'car']);
+
+		$this->object->setFallbackCatalogue($fallbackCatalogue);
+
+		$this->assertTrue($this->object->definesMessage('foo'));
+		$this->assertFalse($this->object->definesMessage('goo'));
+	}
+
+	/**
+	 * @testdox  Verify that a message is retrieved from the catalogue when the key is registered
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::getMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 */
+	public function testAMessageIsRetrievedFromTheCatalogueWhenTheKeyIsRegistered()
+	{
+		$this->object->addMessage('foo', 'bar');
+
+		$this->assertSame('bar', $this->object->getMessage('foo'));
+	}
+
+	/**
+	 * @testdox  Verify that the key is returned when it does not exist in the catalogue
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::getMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 */
+	public function testTheKeyIsReturnedWhenItDoesNotExistInTheCatalogue()
+	{
+		$this->assertSame('FOO', $this->object->getMessage('foo'));
+	}
+
+	/**
+	 * @testdox  Verify that a message is retrieved from the fallback catalogue when the key is registered
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::getMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 * @uses     Joomla\Language\MessageCatalogue::setFallbackCatalogue
+	 */
+	public function testAMessageIsRetrievedFromTheFallbackCatalogueWhenTheKeyIsRegistered()
+	{
+		$fallbackCatalogue = new MessageCatalogue('en-US', ['foo' => 'bar']);
+
+		$this->object->setFallbackCatalogue($fallbackCatalogue);
+
+		$this->assertSame('bar', $this->object->getMessage('foo'));
+	}
+
+	/**
+	 * @testdox  Verify that the catalogue's messages are returned
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::getMessages
+	 */
+	public function testTheCataloguesMessagesAreReturned()
+	{
+		$this->assertSame([], $this->object->getMessages());
+	}
+
+	/**
+	 * @testdox  Verify that two catalogues are merged
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::mergeCatalogue
+	 * @uses     Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 */
+	public function testTwoCataloguesAreMerged()
+	{
+		$this->object->addMessage('foo', 'bar');
+
+		$secondCatalogue = new MessageCatalogue('en-GB', ['goo' => 'car']);
+
+		$this->object->mergeCatalogue($secondCatalogue);
+
+		$this->assertAttributeSame(['FOO' => 'bar', 'GOO' => 'car'], 'messages', $this->object);
+	}
+
+	/**
+	 * @testdox  Verify that two catalogues are not merged when the language codes differ
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::mergeCatalogue
+	 * @uses     Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 * @expectedException  \LogicException
+	 * @expectedExceptionMessage  Cannot merge a catalogue that does not have the same language code.
+	 */
+	public function testTwoCataloguesAreNotMergedWhenTheLanguageCodesDiffer()
+	{
+		$this->object->addMessage('foo', 'bar');
+
+		$secondCatalogue = new MessageCatalogue('en-US', ['goo' => 'car']);
+
+		$this->object->mergeCatalogue($secondCatalogue);
+	}
+
+	/**
+	 * @testdox  Verify that the catalogue accurately reports key presence
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::hasMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 */
+	public function testTheCatalogueAccuratelyReportsKeyPresence()
+	{
+		$this->object->addMessage('foo', 'bar');
+
+		$this->assertTrue($this->object->hasMessage('foo'));
+		$this->assertFalse($this->object->hasMessage('goo'));
+	}
+
+	/**
+	 * @testdox  Verify that the catalogue accurately reports key presence from a fallback catalogue
+	 *
+	 * @covers   Joomla\Language\MessageCatalogue::hasMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessage
+	 * @uses     Joomla\Language\MessageCatalogue::addMessages
+	 */
+	public function testTheCatalogueAccuratelyReportsKeyPresenceFromAFallbackCatalogue()
+	{
+		$fallbackCatalogue = new MessageCatalogue('en-US', ['foo' => 'bar']);
+
+		$this->object->setFallbackCatalogue($fallbackCatalogue);
+
+		$this->assertTrue($this->object->hasMessage('foo'));
+		$this->assertFalse($this->object->hasMessage('goo'));
+	}
+}


### PR DESCRIPTION
### Summary of Changes

Right now the root Language object is a kind of super object doing all things language related, primarily acting as a metadata storage and message catalogue manager.  For that second aspect of things, we can start to extract some of this out to separate objects, and that's what this PR starts to do.

This PR creates a new `MessageCatalogue` object which will act as a simple data object storing the internal message store.  The catalogue API is simply methods to add to the data store and read from it.  It also incorporates support for creating a fallback catalogue, where instead of loading the base message store with strings from all languages as can happen now there can be separate catalogues per language (i.e. I could configure a German catalogue with an English fallback).

### Testing Instructions

Review the tests to see how things are supposed to work.  Externally there is no behavior change at the moment.

### Documentation Changes Required

Document new API and storage concept

### TODO

- [ ] Deprecate `Language::$strings` on 1.x branch