### PR TITLE
[2.0][WIP] Extracting file loading to a separate API

### DIFF
--- a/src/DebugParserInterface.php
+++ b/src/DebugParserInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Part of the Joomla Framework Language Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Language;
+
+/**
+ * Interface describing a language file parser capable of debugging a file
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface DebugParserInterface extends ParserInterface
+{
+	/**
+	 * Parse a file and check its contents for valid structure
+	 *
+	 * @param   string  $filename  The name of the file.
+	 *
+	 * @return  string[]  Array containing a list of errors
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function debugFile(string $filename): array;
+}

--- a/src/Language.php
+++ b/src/Language.php
@@ -136,15 +136,24 @@ class Language
 	protected $catalogue;
 
 	/**
+	 * Language parser registry
+	 *
+	 * @var    ParserRegistry
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $parserRegistry;
+
+	/**
 	 * Constructor activating the default information of the language.
 	 *
-	 * @param   string   $path   The base path to the language folder
-	 * @param   string   $lang   The language
-	 * @param   boolean  $debug  Indicates if language debugging is enabled.
+	 * @param   ParserRegistry  $parserRegistry  A registry containing the supported file parsers
+	 * @param   string          $path            The base path to the language folder
+	 * @param   string          $lang            The language
+	 * @param   boolean         $debug           Indicates if language debugging is enabled
 	 *
 	 * @since   1.0
 	 */
-	public function __construct($path, $lang = '', $debug = false)
+	public function __construct(ParserRegistry $parserRegistry, string $path, $lang = '', $debug = false)
 	{
 		if (empty($path))
 		{
@@ -160,6 +169,8 @@ class Language
 
 		$this->metadata = $this->helper->getMetadata($this->lang, $this->basePath);
 		$this->setDebug($debug);
+
+		$this->parserRegistry = $parserRegistry;
 
 		$basePath = $this->helper->getLanguagePath($this->basePath);
 
@@ -475,7 +486,15 @@ class Language
 			ini_set('track_errors', true);
 		}
 
-		$strings = @parse_ini_file($filename);
+		try
+		{
+			$strings = $this->parserRegistry->get(pathinfo($filename, PATHINFO_EXTENSION))->loadFile($filename);
+		}
+		catch (\RuntimeException $exception)
+		{
+			// TODO - This shouldn't be absorbed
+			$strings = [];
+		}
 
 		if ($this->debug)
 		{
@@ -508,72 +527,22 @@ class Language
 		}
 
 		// Initialise variables for manually parsing the file for common errors.
-		$blacklist    = ['YES', 'NO', 'NULL', 'FALSE', 'ON', 'OFF', 'NONE', 'TRUE'];
 		$debug        = $this->setDebug(false);
-		$errors       = [];
 		$php_errormsg = null;
 
-		// Open the file as a stream.
-		$file = new \SplFileObject($filename);
+		$parser = $this->parserRegistry->get(pathinfo($filename, PATHINFO_EXTENSION));
 
-		foreach ($file as $lineNumber => $line)
+		if (!($parser instanceof DebugParserInterface))
 		{
-			// Avoid BOM error as BOM is OK when using parse_ini.
-			if ($lineNumber == 0)
-			{
-				$line = str_replace("\xEF\xBB\xBF", '', $line);
-			}
-
-			$line = trim($line);
-
-			// Ignore comment lines.
-			if (!strlen($line) || $line['0'] == ';')
-			{
-				continue;
-			}
-
-			// Ignore grouping tag lines, like: [group]
-			if (preg_match('#^\[[^\]]*\](\s*;.*)?$#', $line))
-			{
-				continue;
-			}
-
-			$realNumber = $lineNumber + 1;
-
-			// Check for any incorrect uses of _QQ_.
-			if (strpos($line, '_QQ_') !== false)
-			{
-				$errors[] = $realNumber;
-				continue;
-			}
-
-			// Check for odd number of double quotes.
-			if (substr_count($line, '"') % 2 != 0)
-			{
-				$errors[] = $realNumber;
-				continue;
-			}
-
-			// Check that the line passes the necessary format.
-			if (!preg_match('#^[A-Z][A-Z0-9_\*\-\.]*\s*=\s*".*"(\s*;.*)?$#', $line))
-			{
-				$errors[] = $realNumber;
-				continue;
-			}
-
-			// Check that the key is not in the blacklist.
-			$key = strtoupper(trim(substr($line, 0, strpos($line, '='))));
-
-			if (in_array($key, $blacklist))
-			{
-				$errors[] = $realNumber;
-			}
+			return 0;
 		}
+
+		$errors = $parser->debugFile($filename);
 
 		// Check if we encountered any errors.
 		if (count($errors))
 		{
-			$this->errorfiles[$filename] = $filename . ' - error(s) in line(s) ' . implode(', ', $errors);
+			$this->errorfiles[$filename] = $filename . ' - error(s) ' . implode(', ', $errors);
 		}
 		elseif ($php_errormsg)
 		{

--- a/src/LanguageFactory.php
+++ b/src/LanguageFactory.php
@@ -59,7 +59,10 @@ class LanguageFactory
 		$path = $path ?: $this->getLanguageDirectory();
 		$lang = $lang ?: $this->getDefaultLanguage();
 
-		return new Language($path, $lang, $debug);
+		$loaderRegistry = new ParserRegistry;
+		$loaderRegistry->add(new Parser\IniParser);
+
+		return new Language($loaderRegistry, $path, $lang, $debug);
 	}
 
 	/**

--- a/src/Parser/IniParser.php
+++ b/src/Parser/IniParser.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Part of the Joomla Framework Language Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Language\Parser;
+
+use Joomla\Language\DebugParserInterface;
+
+/**
+ * Language file parser for INI files
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class IniParser implements DebugParserInterface
+{
+	/**
+	 * Parse a file and check its contents for valid structure
+	 *
+	 * @param   string  $filename  The name of the file.
+	 *
+	 * @return  string[]  Array containing a list of errors
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function debugFile(string $filename): array
+	{
+		// Initialise variables for manually parsing the file for common errors.
+		$blacklist = ['YES', 'NO', 'NULL', 'FALSE', 'ON', 'OFF', 'NONE', 'TRUE'];
+		$errors    = [];
+
+		// Open the file as a stream.
+		foreach (new \SplFileObject($filename) as $lineNumber => $line)
+		{
+			// Avoid BOM error as BOM is OK when using parse_ini.
+			if ($lineNumber == 0)
+			{
+				$line = str_replace("\xEF\xBB\xBF", '', $line);
+			}
+
+			$line = trim($line);
+
+			// Ignore comment lines.
+			if (!strlen($line) || $line[0] == ';')
+			{
+				continue;
+			}
+
+			// Ignore grouping tag lines, like: [group]
+			if (preg_match('#^\[[^\]]*\](\s*;.*)?$#', $line))
+			{
+				continue;
+			}
+
+			$realNumber = $lineNumber + 1;
+
+			// Check for any incorrect uses of _QQ_.
+			if (strpos($line, '_QQ_') !== false)
+			{
+				$errors[] = 'The deprecated constant `_QQ_` is in use on line ' . $realNumber;
+
+				continue;
+			}
+
+			// Check for odd number of double quotes.
+			if (substr_count($line, '"') % 2 != 0)
+			{
+				$errors[] = 'There are an odd number of quotes on line ' . $realNumber;
+
+				continue;
+			}
+
+			// Check that the line passes the necessary format.
+			if (!preg_match('#^[A-Z][A-Z0-9_\*\-\.]*\s*=\s*".*"(\s*;.*)?$#', $line))
+			{
+				$errors[] = 'The language key does not meet the required format on line ' . $realNumber;
+
+				continue;
+			}
+
+			// Check that the key is not in the blacklist.
+			$key = strtoupper(trim(substr($line, 0, strpos($line, '='))));
+
+			if (in_array($key, $blacklist))
+			{
+				$errors[] = 'The language key "' . $key . '" is a blacklisted key on line ' . $realNumber;
+
+				$errors[] = $realNumber;
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Get the type of parser
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getType(): string
+	{
+		return 'ini';
+	}
+
+	/**
+	 * Load the strings from a file
+	 *
+	 * @param   string  $filename  The name of the file.
+	 *
+	 * @return  string[]
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException on a load/parse error
+	 */
+	public function loadFile(string $filename): array
+	{
+		$result = @parse_ini_file($filename);
+
+		if ($result === false)
+		{
+			$lastError = error_get_last();
+
+			$errorMessage = $lastError['message'] ?? 'Unknown Error';
+
+			throw new \RuntimeException(
+				sprintf('Could not process file `%s`: %s', $errorMessage, $filename)
+			);
+		}
+
+		return $result;
+	}
+}

--- a/src/Parser/IniParser.php
+++ b/src/Parser/IniParser.php
@@ -44,7 +44,7 @@ class IniParser implements DebugParserInterface
 			$line = trim($line);
 
 			// Ignore comment lines.
-			if (!strlen($line) || $line[0] == ';')
+			if (!\strlen($line) || $line[0] == ';')
 			{
 				continue;
 			}
@@ -84,7 +84,7 @@ class IniParser implements DebugParserInterface
 			// Check that the key is not in the blacklist.
 			$key = strtoupper(trim(substr($line, 0, strpos($line, '='))));
 
-			if (in_array($key, $blacklist))
+			if (\in_array($key, $blacklist))
 			{
 				$errors[] = 'The language key "' . $key . '" is a blacklisted key on line ' . $realNumber;
 

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Part of the Joomla Framework Language Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Language;
+
+/**
+ * Interface describing a language file loader
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface ParserInterface
+{
+	/**
+	 * Get the type of loader
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getType(): string;
+
+	/**
+	 * Load the strings from a file
+	 *
+	 * @param   string  $filename  The name of the file.
+	 *
+	 * @return  string[]
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException on a load/parse error
+	 */
+	public function loadFile(string $filename): array;
+}

--- a/src/ParserRegistry.php
+++ b/src/ParserRegistry.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Part of the Joomla Framework Language Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Language;
+
+/**
+ * Registry of file parsers
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ParserRegistry
+{
+	/**
+	 * A map of the registered parsers
+	 *
+	 * @var    ParserInterface[]
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $parserMap = [];
+
+	/**
+	 * Register a parser, overridding a previously registered parser for the given type
+	 *
+	 * @param   ParserInterface  $parser  The parser to registery
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function add(ParserInterface $parser)
+	{
+		$this->parserMap[$parser->getType()] = $parser;
+	}
+
+	/**
+	 * Get the parser for a given type
+	 *
+	 * @param   string  $type  The parser type to retrieve
+	 *
+	 * @return  ParserInterface
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function get(string $type): ParserInterface
+	{
+		if (!$this->has($type))
+		{
+			throw new \InvalidArgumentException(sprintf('There is not a parser registered for the `%s` type.', $type));
+		}
+
+		return $this->parserMap[$type];
+	}
+
+	/**
+	 * Check if a parser is registered for the given type
+	 *
+	 * @param   string  $type  The parser type to check (typically the file extension)
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function has(string $type): bool
+	{
+		return isset($this->parserMap[$type]);
+	}
+}

--- a/tests/LanguageTest.php
+++ b/tests/LanguageTest.php
@@ -7,6 +7,8 @@
 namespace Joomla\Language\Tests;
 
 use Joomla\Language\Language;
+use Joomla\Language\Parser\IniParser;
+use Joomla\Language\ParserRegistry;
 use Joomla\Test\TestHelper;
 use PHPUnit\Framework\TestCase;
 
@@ -21,6 +23,13 @@ class LanguageTest extends TestCase
 	 * @var  Language
 	 */
 	protected $object;
+
+	/**
+	 * File loader registry
+	 *
+	 * @var  ParserRegistry
+	 */
+	protected $parserRegistry;
 
 	/**
 	 * Path to language folder used for testing
@@ -39,8 +48,11 @@ class LanguageTest extends TestCase
 	{
 		parent::setUp();
 
+		$this->parserRegistry = new ParserRegistry;
+		$this->parserRegistry->add(new IniParser);
+
 		$this->testPath = __DIR__ . '/data';
-		$this->object   = new Language($this->testPath, 'en-GB');
+		$this->object   = new Language($this->parserRegistry, $this->testPath, 'en-GB');
 		$this->object->load();
 	}
 
@@ -53,7 +65,7 @@ class LanguageTest extends TestCase
 	 */
 	public function testVerifyThatLanguageIsInstantiatedCorrectly()
 	{
-		$this->assertInstanceOf('Joomla\\Language\\Language', new Language($this->testPath));
+		$this->assertInstanceOf('Joomla\\Language\\Language', new Language($this->parserRegistry, $this->testPath));
 	}
 
 	/**

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -7,6 +7,8 @@
 namespace Joomla\Language\Tests;
 
 use Joomla\Language\LanguageFactory;
+use Joomla\Language\Parser\IniParser;
+use Joomla\Language\ParserRegistry;
 use Joomla\Language\Text;
 use Joomla\Language\Language;
 use PHPUnit\Framework\TestCase;
@@ -29,6 +31,13 @@ class TextTest extends TestCase
 	 * @var  Text
 	 */
 	protected $object;
+
+	/**
+	 * File parser registry
+	 *
+	 * @var  ParserRegistry
+	 */
+	private $parserRegistry;
 
 	/**
 	 * Path to language folder used for testing
@@ -56,7 +65,10 @@ class TextTest extends TestCase
 	{
 		parent::setUp();
 
-		$language = new Language(self::$testPath, 'en-GB');
+		$this->parserRegistry = new ParserRegistry;
+		$this->parserRegistry->add(new IniParser);
+
+		$language = new Language($this->parserRegistry, self::$testPath, 'en-GB');
 		$language->load();
 		$this->object = new Text($language);
 	}
@@ -71,7 +83,7 @@ class TextTest extends TestCase
 	 */
 	public function testVerifyThatTextIsInstantiatedCorrectly()
 	{
-		$this->assertInstanceOf('Joomla\\Language\\Text', new Text(new Language(self::$testPath)));
+		$this->assertInstanceOf('Joomla\\Language\\Text', new Text(new Language($this->parserRegistry, self::$testPath)));
 	}
 
 	/**
@@ -97,7 +109,7 @@ class TextTest extends TestCase
 	 */
 	public function testVerifyThatSetLanguageReturnsSelf()
 	{
-		$this->assertSame($this->object, $this->object->setLanguage(new Language(self::$testPath, 'de-DE')));
+		$this->assertSame($this->object, $this->object->setLanguage(new Language($this->parserRegistry, self::$testPath, 'de-DE')));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Right now our API is hardcoded to only accept INI language files, and the language file processing is included in the `Language` "superclass" (for lack of a better name).  We can kill two birds with one stone by extracting the responsibility for loading files to its own API and make that API flexible enough to allow other file types without us really caring what the source is.

So this PR creates a new `LoaderInterface` defining what a file loader should do (load the contents of a file into an array for use in the catalogue), creates a `IniLoader` to parse our INI files, and a factory for tracking the available loader types.

### TODO

- [x] I'm not impressed with the `LoaderFactory` yet.  Seems like this should just go into the `LanguageFactory`, but then we need to make `Language` factory aware
- [x] Loader needs getter/setter
- [ ] We need to re-think the internals of `Language::load()` and its internal method calls now to be able to transition to the new API
- [x] The `debugFile` method would need redoing next, as right now it too expects INI files (do we put debugging into the `LoaderInterface`, have a sub interface adding debug capability to loaders on an optional basis, something else?

### Testing Instructions

### Documentation Changes Required
