### PR TITLE
[4.x] update dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "joomla/di": "^4.0",
         "joomla/registry": "^4.0",
         "joomla/test": "^4.0",
-        "phpunit/phpunit": "^12.2.6",
+        "phpunit/phpunit": "^12.2.6 || ^13.0",
         "squizlabs/php_codesniffer": "^3.7.2",
         "phpstan/phpstan": "^2.1.17",
         "phpstan/phpstan-deprecation-rules": "^2.0.3"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "joomla/registry": "^4.0",
         "joomla/test": "^4.0",
         "phpunit/phpunit": "^12.2.6 || ^13.0",
-        "squizlabs/php_codesniffer": "^3.7.2",
+        "squizlabs/php_codesniffer": "^4.0",
         "phpstan/phpstan": "^2.1.17",
         "phpstan/phpstan-deprecation-rules": "^2.0.3"
     },

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -21,7 +21,7 @@
         <exclude name="Generic.Files.LineLength.TooLong"/>
     </rule>
 
-    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+    <rule ref="Squiz.Classes.ValidClassName.NotPascalCase">
         <exclude-pattern type="relative">src/Localise/En_GBLocalise\.php</exclude-pattern>
     </rule>
 


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

- allow phpunit 13 (php 8.4 and above)
- use php_codesniffer version 4

### Testing Instructions

ci/cd

### Documentation Changes Required

no