### PR TITLE
[4.x] convert PHPUnit metadata doc-comment to attribute

### DIFF
--- a/tests/LanguageFactoryTest.php
+++ b/tests/LanguageFactoryTest.php
@@ -9,14 +9,28 @@ namespace Joomla\Language\Tests;
 
 use Joomla\Language\Language;
 use Joomla\Language\LanguageFactory;
+use Joomla\Language\LanguageHelper;
 use Joomla\Language\Localise\En_GBLocalise;
+use Joomla\Language\MessageCatalogue;
+use Joomla\Language\Parser\IniParser;
+use Joomla\Language\ParserRegistry;
 use Joomla\Language\Stemmer\Porteren;
 use Joomla\Language\Text;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Language\Language.
  */
+#[CoversClass(LanguageFactory::class)]
+#[UsesClass(IniParser::class)]
+#[UsesClass(Language::class)]
+#[UsesClass(LanguageHelper::class)]
+#[UsesClass(MessageCatalogue::class)]
+#[UsesClass(ParserRegistry::class)]
+#[UsesClass(Text::class)]
 class LanguageFactoryTest extends TestCase
 {
     /**
@@ -47,42 +61,25 @@ class LanguageFactoryTest extends TestCase
         $this->object   = new LanguageFactory();
     }
 
-    /**
-     * @testdox  Verify the default return of getDefaultLanguage()
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify the default return of getDefaultLanguage()')]
     public function testTheDefaultReturnOfGetDefaultLanguage()
     {
         $this->assertSame('en-GB', $this->object->getDefaultLanguage());
     }
 
-    /**
-     * @testdox  Verify the default return of getLanguageDirectory()
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify the default return of getLanguageDirectory()')]
     public function testTheDefaultReturnOfGetLanguageDirectory()
     {
         $this->assertEmpty($this->object->getLanguageDirectory());
     }
 
-    /**
-     * @testdox  Verify that getLocalise() returns the default localise class when none exists
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that getLocalise() returns the default localise class when none exists')]
     public function testVerifyGetLocaliseReturnsDefaultLocaliseWhenNoneExists()
     {
         $this->assertInstanceOf(En_GBLocalise::class, $this->object->getLocalise('fr-FR', $this->testPath));
     }
 
-    /**
-     * @testdox  Verify that getLocalise() returns the correct localise class when it exists
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify that getLocalise() returns the correct localise class when it exists')]
     public function testVerifyGetLocaliseReturnedWhenExists()
     {
         // Class exists check in PHPUnit happens before we import the file in our method
@@ -91,11 +88,7 @@ class LanguageFactoryTest extends TestCase
         $this->assertInstanceOf('\\Xx_XXLocalise', $this->object->getLocalise('xx-XX', $this->testPath));
     }
 
-    /**
-     * @testdox  Verify that getLocalise() validates the cache when a localise object exists
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify that getLocalise() validates the cache when a localise object exists')]
     public function testVerifyGetLocaliseValidatesTheCacheWhenALocaliseObjectExists()
     {
         // Class exists check in PHPUnit happens before we import the file in our method
@@ -107,30 +100,13 @@ class LanguageFactoryTest extends TestCase
         $this->assertInstanceOf('\\Xx_XXLocalise', $this->object->getLocalise('xx-XX', $this->testPath));
     }
 
-    /**
-     * @testdox  Verify that getLanguage() returns a Language object
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that getLanguage() returns a Language object')]
     public function testVerifyGetLanguageReturnsALanguageObject()
     {
         $this->assertInstanceOf(Language::class, $this->object->getLanguage(null, $this->testPath));
     }
 
-    /**
-     * @testdox  Verify that getLanguage() throws an \InvalidArgumentException when no path is given
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that getLanguage() throws an \InvalidArgumentException when no path is given')]
     public function testVerifyGetLanguageThrowsAnExceptionWhenNoPathIsGiven()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -138,38 +114,20 @@ class LanguageFactoryTest extends TestCase
         $this->object->getLanguage('es-ES');
     }
 
-    /**
-     * @testdox  Verify that getText() returns a Text object
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     * @uses     Joomla\Language\Text
-     */
+    #[TestDox('Verify that getText() returns a Text object')]
     public function testVerifyThatGetTextReturnsATextObject()
     {
         $language = $this->object->getLanguage(null, $this->testPath);
         $this->assertInstanceOf(Text::class, $this->object->getText($language));
     }
 
-    /**
-     * @testdox  Verify getInstance() returns an instance of the correct object
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify getInstance() returns an instance of the correct object')]
     public function testGetStemmerReturnsAnInstanceOfTheCorrectObject()
     {
         $this->assertInstanceOf(Porteren::class, $this->object->getStemmer('porteren'));
     }
 
-    /**
-     * @testdox  Verify getInstance() returns an instance of the correct object
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify getInstance() returns an instance of the correct object')]
     public function testGetStemmerThrowsAnExceptionIfTheObjectDoesNotExist()
     {
         $this->expectException(\RuntimeException::class);
@@ -177,31 +135,19 @@ class LanguageFactoryTest extends TestCase
         $this->object->getStemmer('unexisting');
     }
 
-    /**
-     * @testdox  Verify setDefaultLanguage() returns the current object
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify setDefaultLanguage() returns the current object')]
     public function testSetDefaultLanguageReturnsTheCurrentObject()
     {
         $this->assertSame($this->object, $this->object->setDefaultLanguage('en-US'));
     }
 
-    /**
-     * @testdox  Verify setLanguageDirectory() returns the current object
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify setLanguageDirectory() returns the current object')]
     public function testSetLanguageDirectoryReturnsTheCurrentObject()
     {
         $this->assertSame($this->object, $this->object->setLanguageDirectory($this->testPath));
     }
 
-    /**
-     * @testdox  Verify setLanguageDirectory() throws an exception when a path does not exist
-     *
-     * @covers   Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify setLanguageDirectory() throws an exception when a path does not exist')]
     public function testSetLanguageDirectoryThrowsAnExceptionWhenAPathDoesNotExist()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/LanguageHelperTest.php
+++ b/tests/LanguageHelperTest.php
@@ -8,11 +8,14 @@
 namespace Joomla\Language\Tests;
 
 use Joomla\Language\LanguageHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Language\LanguageHelper.
  */
+#[CoversClass(LanguageHelper::class)]
 class LanguageHelperTest extends TestCase
 {
     /**
@@ -43,91 +46,55 @@ class LanguageHelperTest extends TestCase
         $this->object   = new LanguageHelper();
     }
 
-    /**
-     * @testdox  Verify that LanguageHelper::exists() locates the language directory
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that LanguageHelper::exists() locates the language directory')]
     public function testVerifyExistsLocatesTheLanguageDirectory()
     {
         $this->assertTrue($this->object->exists('en-GB', $this->testPath));
     }
 
-    /**
-     * @testdox  Verify that LanguageHelper::getMetadata() returns the language metadata
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that LanguageHelper::getMetadata() returns the language metadata')]
     public function testVerifyGetMetadataReturnsTheLanguageMetadata()
     {
         $this->assertIsArray($this->object->getMetadata('en-GB', $this->testPath));
     }
 
-    /**
-     * @testdox  Verify that LanguageHelper::getMetadata() returns null if metadata does not exist
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that LanguageHelper::getMetadata() returns null if metadata does not exist')]
     public function testVerifyGetMetadataReturnsNullIfMetadataDoesNotExist()
     {
         $this->assertNull($this->object->getMetadata('es-ES', $this->testPath));
     }
 
-    /**
-     * @testdox  Verify that Language::getKnownLanguages() returns an array of known languages
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that Language::getKnownLanguages() returns an array of known languages')]
     public function testVerifyGetKnownLanguagesReturnsAnArrayOfKnownLanguages()
     {
         $this->assertIsArray($this->object->getKnownLanguages($this->testPath));
     }
 
-    /**
-     * @testdox  Verify that Language::getLanguagePath() returns the correct language path
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that Language::getLanguagePath() returns the correct language path')]
     public function testVerifyGetLanguagePathReturnsTheCorrectLanguagePath()
     {
         $this->assertSame($this->testPath . '/language', $this->object->getLanguagePath($this->testPath));
     }
 
-    /**
-     * @testdox  Verify that Language::parseLanguageFiles() returns an array
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that Language::parseLanguageFiles() returns an array')]
     public function testVerifyParseLanguageFilesReturnsAnArray()
     {
         $this->assertIsArray($this->object->parseLanguageFiles($this->testPath));
     }
 
-    /**
-     * @testdox  Verify that Language::parseXMLLanguageFile() returns an array
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that Language::parseXMLLanguageFile() returns an array')]
     public function testVerifyParseXMLLanguageFileReturnsAnArray()
     {
         $this->assertIsArray($this->object->parseXMLLanguageFile($this->testPath . '/language/en-GB/en-GB.xml'));
     }
 
-    /**
-     * @testdox  Verify that Language::parseXMLLanguageFile() returns null if the top XML tag is not metafile
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that Language::parseXMLLanguageFile() returns null if the top XML tag is not metafile')]
     public function testVerifyParseXMLLanguageFileReturnsNullIfTheTopXMLTagIsNotMetafile()
     {
         $this->assertNull($this->object->parseXMLLanguageFile($this->testPath . '/language/xx-XX/xx-XX.xml'));
     }
 
-    /**
-     * @testdox  Verify that Language::parseXMLLanguageFile() throws an exception if the file is not found
-     *
-     * @covers   Joomla\Language\LanguageHelper
-     */
+    #[TestDox('Verify that Language::parseXMLLanguageFile() throws an exception if the file is not found')]
     public function testVerifyParseXMLLanguageFileThrowsAnExceptionIfTheFileIsNotFound()
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/LanguageTest.php
+++ b/tests/LanguageTest.php
@@ -8,14 +8,26 @@
 namespace Joomla\Language\Tests;
 
 use Joomla\Language\Language;
+use Joomla\Language\LanguageFactory;
+use Joomla\Language\LanguageHelper;
+use Joomla\Language\MessageCatalogue;
 use Joomla\Language\Parser\IniParser;
 use Joomla\Language\ParserRegistry;
 use Joomla\Test\TestHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Language\Language.
  */
+#[CoversClass(Language::class)]
+#[UsesClass(IniParser::class)]
+#[UsesClass(LanguageFactory::class)]
+#[UsesClass(LanguageHelper::class)]
+#[UsesClass(MessageCatalogue::class)]
+#[UsesClass(ParserRegistry::class)]
 class LanguageTest extends TestCase
 {
     /**
@@ -57,228 +69,93 @@ class LanguageTest extends TestCase
         $this->object->load();
     }
 
-    /**
-     * @testdox  Verify that Language is instantiated correctly
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language is instantiated correctly')]
     public function testVerifyThatLanguageIsInstantiatedCorrectly()
     {
         $this->assertInstanceOf(Language::class, new Language($this->parserRegistry, $this->testPath));
     }
 
-    /**
-     * @testdox  Verify that Language::translate() returns an empty string when one is input
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::translate() returns an empty string when one is input')]
     public function testTranslateReturnsEmptyStringWhenGivenAnEmptyString()
     {
         $this->assertEmpty($this->object->translate(''));
     }
 
-    /**
-     * @testdox  Verify that Language::translate() returns the correct string for a key
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::translate() returns the correct string for a key')]
     public function testTranslateReturnsTheCorrectStringForAKey()
     {
         $this->assertSame('Bar', $this->object->translate('FOO'));
     }
 
-    /**
-     * @testdox  Verify that Language::translate() returns the correct string for a key in debug mode
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::translate() returns the correct string for a key in debug mode')]
     public function testTranslateReturnsTheCorrectStringForAKeyInDebugMode()
     {
         $this->object->setDebug(true);
         $this->assertSame('**Bar**', $this->object->translate('FOO'));
     }
 
-    /**
-     * @testdox  Verify that Language::translate() identifies a key as unknown in debug mode
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::translate() identifies a key as unknown in debug mode')]
     public function testTranslateIdentifiesAKeyAsUnknownInDebugMode()
     {
         $this->object->setDebug(true);
         $this->assertSame('??BAR??', $this->object->translate('BAR'));
     }
 
-    /**
-     * @testdox  Verify that Language::translate() returns a JavaScript safe string
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::translate() returns a JavaScript safe string')]
     public function testTranslateReturnsAJavascriptSafeKey()
     {
         $this->assertSame('foobar\\\'s', $this->object->translate('foobar\'s', true));
     }
 
-    /**
-     * @testdox  Verify that Language::translate() returns a string without backslashes interpreted
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::translate() returns a string without backslashes interpreted')]
     public function testTranslateReturnsAStringWithoutBackslashesInterpreted()
     {
         $this->assertSame('foobar\\\'s', $this->object->translate('foobar\'s', true, false));
     }
 
-    /**
-     * @testdox  Verify that Language::transliterate() calls defined transliterator
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::transliterate() calls defined transliterator')]
     public function testTransliterateCallsDefinedTransliterator()
     {
         $this->assertSame('Así', $this->object->transliterate('Así'));
     }
 
-    /**
-     * @testdox  Verify that Language::getPluralSuffixes() calls the defined method
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getPluralSuffixes() calls the defined method')]
     public function testGetPluralSuffixesCallsTheDefinedMethod()
     {
         $this->assertIsArray($this->object->getPluralSuffixes(1));
     }
 
-    /**
-     * @testdox  Verify that Language::load() successfully loads the main language file
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::load() successfully loads the main language file')]
     public function testVerifyLoadSuccessfullyLoadsTheMainLanguageFile()
     {
         $this->assertTrue($this->object->load());
     }
 
-    /**
-     * @testdox  Verify that Language::load() successfully loads a language file
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::load() successfully loads a language file')]
     public function testVerifyLoadSuccessfullyLoadsALanguageFile()
     {
         $this->assertTrue($this->object->load('good'));
     }
 
-    /**
-     * @testdox  Verify that Language::load() fails to load an extension language file with errors
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::load() fails to load an extension language file with errors')]
     public function testVerifyLoadFailsToLoadAnExtensionLanguageFileWithErrors()
     {
         $this->assertFalse($this->object->load('bad'));
     }
 
-    /**
-     * @testdox  Verify that Language::load() successfully loads a language file
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::load() successfully loads a language file')]
     public function testVerifyLoadLanguageSuccessfullyLoadsALanguageFile()
     {
         $this->assertTrue(TestHelper::invoke($this->object, 'loadLanguage', $this->testPath . '/good.ini'));
     }
 
-    /**
-     * @testdox  Verify that Language::parse() successfully parses a language file
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::parse() successfully parses a language file')]
     public function testVerifyParseSuccessfullyParsesALanguageFile()
     {
         $this->assertNotEmpty(TestHelper::invoke($this->object, 'parse', $this->testPath . '/good.ini'));
     }
 
-    /**
-     * @testdox  Verify that Language::parse() successfully parses a language file in debug mode
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::parse() successfully parses a language file in debug mode')]
     public function testVerifyParseSuccessfullyParsesALanguageFileInDebugMode()
     {
         $this->object->setDebug(true);
@@ -286,31 +163,13 @@ class LanguageTest extends TestCase
         $this->assertNotEmpty(TestHelper::invoke($this->object, 'parse', $this->testPath . '/good.ini'));
     }
 
-    /**
-     * @testdox  Verify that Language::parse() fails to parse a language file with errors
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::parse() fails to parse a language file with errors')]
     public function testVerifyParseFailsToParseALanguageFileWithErrors()
     {
         $this->assertEmpty(TestHelper::invoke($this->object, 'parse', $this->testPath . '/bad.ini'));
     }
 
-    /**
-     * @testdox  Verify that Language::parse() fails to parse a language file with errors in debug mode
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::parse() fails to parse a language file with errors in debug mode')]
     public function testVerifyParseFailsToParseALanguageFileWithErrorsInDebugMode()
     {
         $this->object->setDebug(true);
@@ -318,151 +177,61 @@ class LanguageTest extends TestCase
         $this->assertEmpty(TestHelper::invoke($this->object, 'parse', $this->testPath . '/bad.ini'));
     }
 
-    /**
-     * @testdox  Verify that Language::debugFile() finds no errors in a good file
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::debugFile() finds no errors in a good file')]
     public function testVerifyDebugFileFindsNoErrorsInAGoodFile()
     {
         $this->assertSame(0, $this->object->debugFile($this->testPath . '/good.ini'));
     }
 
-    /**
-     * @testdox  Verify that Language::debugFile() finds errors in a bad file
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::debugFile() finds errors in a bad file')]
     public function testVerifyDebugFileFindsErrorsInABadFile()
     {
         $this->assertGreaterThan(0, $this->object->debugFile($this->testPath . '/bad.ini'));
     }
 
-    /**
-     * @testdox  Verify that Language::get() returns the correct metadata
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::get() returns the correct metadata')]
     public function testVerifyThatGetReturnsTheCorrectMetadata()
     {
         $this->assertEquals('en-GB', $this->object->get('tag'));
     }
 
-    /**
-     * @testdox  Verify that Language::get() returns the default if metadata does not exist
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::get() returns the default if metadata does not exist')]
     public function testVerifyThatGetReturnsTheDefaultIfMetadataDoesNotExist()
     {
         $this->assertEquals('default', $this->object->get('doesnotexist', 'default'));
     }
 
-    /**
-     * @testdox  Verify that Language::getBasePath() returns the correct path
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getBasePath() returns the correct path')]
     public function testVerifyThatGetBasePathReturnsTheCorrectPath()
     {
         $this->assertSame($this->testPath, $this->object->getBasePath());
     }
 
-    /**
-     * @testdox  Verify that Language::getCallerInfo() returns an array
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getCallerInfo() returns an array')]
     public function testVerifyGetCallerInfoReturnsAnArray()
     {
         $this->assertIsArray(TestHelper::invoke($this->object, 'getCallerInfo'));
     }
 
-    /**
-     * @testdox  Verify that Language::getName() returns the correct metadata
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getName() returns the correct metadata')]
     public function testVerifyThatGetNameReturnsTheCorrectMetadata()
     {
         $this->assertSame('English (United Kingdom)', $this->object->getName());
     }
 
-    /**
-     * @testdox  Verify that Language::getPaths() default returns an array
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getPaths() default returns an array')]
     public function testVerifyThatGetPathsDefaultReturnsAnArray()
     {
         $this->assertIsArray($this->object->getPaths());
     }
 
-    /**
-     * @testdox  Verify that Language::getPaths() returns null for an unloaded extension
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getPaths() returns null for an unloaded extension')]
     public function testVerifyThatGetPathsReturnsNullForAnUnloadedExtension()
     {
         $this->assertNull($this->object->getPaths('good'));
     }
 
-    /**
-     * @testdox  Verify that Language::getPaths() returns the extension path for a loaded extension
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getPaths() returns the extension path for a loaded extension')]
     public function testVerifyThatGetPathsReturnsTheExtensionPathForALoadedExtension()
     {
         $this->object->load('good');
@@ -470,211 +239,85 @@ class LanguageTest extends TestCase
         $this->assertIsArray($this->object->getPaths('good'));
     }
 
-    /**
-     * @testdox  Verify that Language::getErrorFiles() default returns an array
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getErrorFiles() default returns an array')]
     public function testVerifyThatGetErrorFilesDefaultReturnsAnArray()
     {
         $this->assertIsArray($this->object->getErrorFiles());
     }
 
-    /**
-     * @testdox  Verify that Language::getTag() returns the correct metadata
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getTag() returns the correct metadata')]
     public function testVerifyThatGetTagReturnsTheCorrectMetadata()
     {
         $this->assertSame('en-GB', $this->object->getTag());
     }
 
-    /**
-     * @testdox  Verify that Language::isRTL() default returns false
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::isRTL() default returns false')]
     public function testVerifyThatIsRTLDefaultReturnsFalse()
     {
         $this->assertFalse($this->object->isRTL());
     }
 
-    /**
-     * @testdox  Verify that Language::setDebug() returns the previous debug state
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::setDebug() returns the previous debug state')]
     public function testVerifyThatSetDebugReturnsThePreviousDebugState()
     {
         $this->assertFalse($this->object->setDebug(true));
     }
 
-    /**
-     * @testdox  Verify that Language::getDebug() default returns false
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getDebug() default returns false')]
     public function testVerifyThatGetDebugDefaultReturnsFalse()
     {
         $this->assertFalse($this->object->getDebug());
     }
 
-    /**
-     * @testdox  Verify that Language::setDefault() returns the previous default language
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::setDefault() returns the previous default language')]
     public function testVerifyThatSetDefaultReturnsThePreviousDefaultLanguage()
     {
         $this->assertSame('en-GB', $this->object->setDefault('de-DE'));
     }
 
-    /**
-     * @testdox  Verify that Language::getDefault() default returns 'en-GB'
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox("Verify that Language::getDefault() default returns 'en-GB'")]
     public function testVerifyTheDefaultReturnForGetDefault()
     {
         $this->assertSame('en-GB', $this->object->getDefault());
     }
 
-    /**
-     * @testdox  Verify that Language::getOrphans() default returns an array
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getOrphans() default returns an array')]
     public function testVerifyThatGetOrphansDefaultReturnsAnArray()
     {
         $this->assertIsArray($this->object->getOrphans());
     }
 
-    /**
-     * @testdox  Verify that Language::getUsed() default returns an array
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getUsed() default returns an array')]
     public function testVerifyThatGetUsedDefaultReturnsAnArray()
     {
         $this->assertIsArray($this->object->getUsed());
     }
 
-    /**
-     * @testdox  Verify that Language::hasKey() returns false for a non-existing language key
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::hasKey() returns false for a non-existing language key')]
     public function testVerifyThatHasKeyReturnsFalseForANonExistingLanguageKey()
     {
         $this->assertFalse($this->object->hasKey('com_admin.key'));
     }
 
-    /**
-     * @testdox  Verify that Language::getLanguage() default returns 'en-GB'
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox("Verify that Language::getLanguage() default returns 'en-GB'")]
     public function testVerifyTheDefaultReturnForGetLanguage()
     {
         $this->assertSame('en-GB', $this->object->getLanguage());
     }
 
-    /**
-     * @testdox  Verify that Language::getLocale() default returns an array
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getLocale() default returns an array')]
     public function testVerifyTheDefaultReturnForGetLocale()
     {
         $this->assertIsArray($this->object->getLocale());
     }
 
-    /**
-     * @testdox  Verify that Language::getFirstDay() default returns an integer for the first day of the week
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getFirstDay() default returns an integer for the first day of the week')]
     public function testVerifyTheDefaultReturnForGetFirstDay()
     {
         $this->assertSame(0, $this->object->getFirstDay());
     }
 
-    /**
-     * @testdox  Verify that Language::getWeekEnd() default returns an array
-     *
-     * @covers   Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Language::getWeekEnd() default returns an array')]
     public function testVerifyTheDefaultReturnForGetWeekEnd()
     {
         $this->assertSame('0,6', $this->object->getWeekEnd());

--- a/tests/LanguageTest.php
+++ b/tests/LanguageTest.php
@@ -192,13 +192,13 @@ class LanguageTest extends TestCase
     #[TestDox('Verify that Language::get() returns the correct metadata')]
     public function testVerifyThatGetReturnsTheCorrectMetadata()
     {
-        $this->assertEquals('en-GB', $this->object->get('tag'));
+        $this->assertSame('en-GB', $this->object->get('tag'));
     }
 
     #[TestDox('Verify that Language::get() returns the default if metadata does not exist')]
     public function testVerifyThatGetReturnsTheDefaultIfMetadataDoesNotExist()
     {
-        $this->assertEquals('default', $this->object->get('doesnotexist', 'default'));
+        $this->assertSame('default', $this->object->get('doesnotexist', 'default'));
     }
 
     #[TestDox('Verify that Language::getBasePath() returns the correct path')]

--- a/tests/Localise/AbstractLocaliseTest.php
+++ b/tests/Localise/AbstractLocaliseTest.php
@@ -11,20 +11,20 @@ namespace Joomla\Language\Tests\Localise;
 
 use Joomla\Language\Localise\AbstractLocalise;
 use Joomla\Language\Tests\stubs\StubLocalise;
-use PHPUnit\Framework\MockObject\MockObject;
+use Joomla\Language\Transliterate;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Language\Localise\AbstractLocalise.
  */
+#[CoversClass(AbstractLocalise::class)]
+#[UsesClass(Transliterate::class)]
 class AbstractLocaliseTest extends TestCase
 {
-    /**
-     * @testdox  Verify that the transliterate method calls the defined transliterator
-     *
-     * @covers   \Joomla\Language\Localise\AbstractLocalise
-     * @uses     \Joomla\Language\Transliterate
-     */
+    #[TestDox('Verify that the transliterate method calls the defined transliterator')]
     public function testTransliterateCallsDefinedTransliterator()
     {
         $localise = new StubLocalise();
@@ -32,11 +32,7 @@ class AbstractLocaliseTest extends TestCase
         $this->assertSame('asi', $localise->transliterate('Así'));
     }
 
-    /**
-     * @testdox  Verify that the plural suffixes are returned
-     *
-     * @covers   Joomla\Language\Localise\AbstractLocalise
-     */
+    #[TestDox('Verify that the plural suffixes are returned')]
     public function testGetPluralSuffixesCallsTheDefinedMethod()
     {
         $localise = new StubLocalise();

--- a/tests/MessageCatalogueTest.php
+++ b/tests/MessageCatalogueTest.php
@@ -8,11 +8,14 @@
 namespace Joomla\Language\Tests;
 
 use Joomla\Language\MessageCatalogue;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Language\MessageCatalogue.
  */
+#[CoversClass(MessageCatalogue::class)]
 class MessageCatalogueTest extends TestCase
 {
     /**
@@ -35,21 +38,13 @@ class MessageCatalogueTest extends TestCase
         $this->object = new MessageCatalogue('en-GB');
     }
 
-    /**
-     * @testdox  Verify the catalogue's language is returned
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox("Verify the catalogue's language is returned")]
     public function testTheCataloguesLanguageIsReturned()
     {
         $this->assertSame('en-GB', $this->object->getLanguage());
     }
 
-    /**
-     * @testdox  Verify that a single message is added to the catalogue
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that a single message is added to the catalogue')]
     public function testASingleMessageIsAddedToTheCatalogue()
     {
         $this->object->addMessage('foo', 'bar');
@@ -57,11 +52,7 @@ class MessageCatalogueTest extends TestCase
         $this->assertSame(['FOO' => 'bar'], $this->object->getMessages());
     }
 
-    /**
-     * @testdox  Verify that multiple messages are added to the catalogue
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that multiple messages are added to the catalogue')]
     public function testMultipleMessagesAreAddedToTheCatalogue()
     {
         $messages = [
@@ -74,11 +65,7 @@ class MessageCatalogueTest extends TestCase
         $this->assertSame(array_change_key_case($messages, CASE_UPPER), $this->object->getMessages());
     }
 
-    /**
-     * @testdox  Verify that the catalogue accurately reports key presence on this catalogue
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that the catalogue accurately reports key presence on this catalogue')]
     public function testTheCatalogueAccuratelyReportsKeyPresenceOnThisCatalogue()
     {
         $this->object->addMessage('foo', 'bar');
@@ -91,11 +78,7 @@ class MessageCatalogueTest extends TestCase
         $this->assertFalse($this->object->definesMessage('goo'));
     }
 
-    /**
-     * @testdox  Verify that a message is retrieved from the catalogue when the key is registered
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that a message is retrieved from the catalogue when the key is registered')]
     public function testAMessageIsRetrievedFromTheCatalogueWhenTheKeyIsRegistered()
     {
         $this->object->addMessage('foo', 'bar');
@@ -103,21 +86,13 @@ class MessageCatalogueTest extends TestCase
         $this->assertSame('bar', $this->object->getMessage('foo'));
     }
 
-    /**
-     * @testdox  Verify that the key is returned when it does not exist in the catalogue
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that the key is returned when it does not exist in the catalogue')]
     public function testTheKeyIsReturnedWhenItDoesNotExistInTheCatalogue()
     {
         $this->assertSame('FOO', $this->object->getMessage('foo'));
     }
 
-    /**
-     * @testdox  Verify that a message is retrieved from the fallback catalogue when the key is registered
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that a message is retrieved from the fallback catalogue when the key is registered')]
     public function testAMessageIsRetrievedFromTheFallbackCatalogueWhenTheKeyIsRegistered()
     {
         $fallbackCatalogue = new MessageCatalogue('en-US', ['foo' => 'bar']);
@@ -127,21 +102,13 @@ class MessageCatalogueTest extends TestCase
         $this->assertSame('bar', $this->object->getMessage('foo'));
     }
 
-    /**
-     * @testdox  Verify that the catalogue's messages are returned
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox("Verify that the catalogue's messages are returned")]
     public function testTheCataloguesMessagesAreReturned()
     {
         $this->assertSame([], $this->object->getMessages());
     }
 
-    /**
-     * @testdox  Verify that two catalogues are merged
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that two catalogues are merged')]
     public function testTwoCataloguesAreMerged()
     {
         $this->object->addMessage('foo', 'bar');
@@ -153,11 +120,7 @@ class MessageCatalogueTest extends TestCase
         $this->assertSame(['FOO' => 'bar', 'GOO' => 'car'], $this->object->getMessages());
     }
 
-    /**
-     * @testdox  Verify that two catalogues are not merged when the language codes differ
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that two catalogues are not merged when the language codes differ')]
     public function testTwoCataloguesAreNotMergedWhenTheLanguageCodesDiffer()
     {
         $this->expectException(\LogicException::class);
@@ -170,11 +133,7 @@ class MessageCatalogueTest extends TestCase
         $this->object->mergeCatalogue($secondCatalogue);
     }
 
-    /**
-     * @testdox  Verify that the catalogue accurately reports key presence
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that the catalogue accurately reports key presence')]
     public function testTheCatalogueAccuratelyReportsKeyPresence()
     {
         $this->object->addMessage('foo', 'bar');
@@ -183,11 +142,7 @@ class MessageCatalogueTest extends TestCase
         $this->assertFalse($this->object->hasMessage('goo'));
     }
 
-    /**
-     * @testdox  Verify that the catalogue accurately reports key presence from a fallback catalogue
-     *
-     * @covers   Joomla\Language\MessageCatalogue
-     */
+    #[TestDox('Verify that the catalogue accurately reports key presence from a fallback catalogue')]
     public function testTheCatalogueAccuratelyReportsKeyPresenceFromAFallbackCatalogue()
     {
         $fallbackCatalogue = new MessageCatalogue('en-US', ['foo' => 'bar']);

--- a/tests/Service/LanguageFactoryProviderTest.php
+++ b/tests/Service/LanguageFactoryProviderTest.php
@@ -11,11 +11,16 @@ use Joomla\DI\Container;
 use Joomla\Language\LanguageFactory;
 use Joomla\Language\Service\LanguageFactoryProvider;
 use Joomla\Registry\Registry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Language\Service\LanguageFactoryProvider.
  */
+#[CoversClass(LanguageFactoryProvider::class)]
+#[UsesClass(LanguageFactory::class)]
 class LanguageFactoryProviderTest extends TestCase
 {
     /**
@@ -51,12 +56,7 @@ class LanguageFactoryProviderTest extends TestCase
         $this->container->set('config', $config);
     }
 
-    /**
-     * @testdox  Verify that the LanguageFactoryProvider returns a LanguageFactory object
-     *
-     * @covers   Joomla\Language\Service\LanguageFactoryProvider
-     * @uses     Joomla\Language\LanguageFactory
-     */
+    #[TestDox('Verify that the LanguageFactoryProvider returns a LanguageFactory object')]
     public function testVerifyTheLanguageObjectIsRegisteredToTheContainer()
     {
         $this->container->registerServiceProvider(new LanguageFactoryProvider());

--- a/tests/Stemmer/PorterenTest.php
+++ b/tests/Stemmer/PorterenTest.php
@@ -8,12 +8,14 @@
 namespace Joomla\Language\Tests\Stemmer;
 
 use Joomla\Language\Stemmer\Porteren;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Porteren.
  */
+#[CoversClass(Porteren::class)]
 class PorterenTest extends TestCase
 {
     /**
@@ -160,8 +162,6 @@ class PorterenTest extends TestCase
      * @param   string  $token   The token to stem.
      * @param   string  $result  The expected result
      * @param   string  $lang    The language of the token.
-     *
-     * @covers  \Joomla\Language\Stemmer\Porteren
      */
     #[DataProvider('dataStemProvider')]
     public function testTheCorrectStemIsReturnedFromAGivenString($token, $result, $lang)

--- a/tests/Stemmer/PorterenTest.php
+++ b/tests/Stemmer/PorterenTest.php
@@ -166,6 +166,6 @@ class PorterenTest extends TestCase
     #[DataProvider('dataStemProvider')]
     public function testTheCorrectStemIsReturnedFromAGivenString($token, $result, $lang)
     {
-        $this->assertEquals($result, $this->object->stem($token, $lang));
+        $this->assertSame($result, $this->object->stem($token, $lang));
     }
 }

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -7,17 +7,29 @@
 
 namespace Joomla\Language\Tests;
 
+use Joomla\Language\Language;
 use Joomla\Language\LanguageFactory;
+use Joomla\Language\LanguageHelper;
+use Joomla\Language\MessageCatalogue;
 use Joomla\Language\Parser\IniParser;
 use Joomla\Language\ParserRegistry;
 use Joomla\Language\Text;
-use Joomla\Language\Language;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for \Joomla\Language\Text.
  */
+#[CoversClass(Text::class)]
+#[UsesClass(IniParser::class)]
+#[UsesClass(Language::class)]
+#[UsesClass(LanguageFactory::class)]
+#[UsesClass(LanguageHelper::class)]
+#[UsesClass(MessageCatalogue::class)]
+#[UsesClass(ParserRegistry::class)]
 class TextTest extends TestCase
 {
     /**
@@ -75,28 +87,14 @@ class TextTest extends TestCase
         $this->object = new Text($language);
     }
 
-    /**
-     * @testdox  Verify that Text is instantiated correctly
-     *
-     * @covers   \Joomla\Language\Text
-     */
     #[DoesNotPerformAssertions]
+    #[TestDox('Verify that Text is instantiated correctly')]
     public function testVerifyThatTextIsInstantiatedCorrectly()
     {
         new Text(new Language($this->parserRegistry, self::$testPath));
     }
 
-    /**
-     * @testdox  Verify that the Language object can be managed
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that the Language object can be managed')]
     public function testSetGetLanguage()
     {
         $language = new Language($this->parserRegistry, self::$testPath, 'de-DE');
@@ -105,193 +103,73 @@ class TextTest extends TestCase
         $this->assertSame($language, $this->object->getLanguage());
     }
 
-    /**
-     * @testdox  Verify that Text::translate() returns an empty string when one is input
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::translate() returns an empty string when one is input')]
     public function testTranslateReturnsEmptyStringWhenGivenAnEmptyString()
     {
         $this->assertEmpty($this->object->translate(''));
     }
 
-    /**
-     * @testdox  Verify that Text::translate() returns the correct string for a key
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::translate() returns the correct string for a key')]
     public function testTranslateReturnsTheCorrectStringForAKey()
     {
         $this->assertSame('Bar', $this->object->translate('Bar'));
     }
 
-    /**
-     * @testdox  Verify that Text::translate() returns the correct string for a key with named parameters
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::translate() returns the correct string for a key with named parameters')]
     public function testTranslateReturnsTheCorrectStringForAKeyWithNamedParameters()
     {
         $this->assertSame('Bar None', $this->object->translate('Bar %value%', ['%value%' => 'None']));
     }
 
-    /**
-     * @testdox  Verify that Text::translate() returns a JavaScript safe string
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::translate() returns a JavaScript safe string')]
     public function testTranslateReturnsAJavascriptSafeKey()
     {
         $this->assertSame('foobar\\\'s', $this->object->translate('foobar\'s', [], true));
     }
 
-    /**
-     * @testdox  Verify that Text::alt() returns the correct string for a key with no alt
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::alt() returns the correct string for a key with no alt')]
     public function testAltReturnsTheCorrectStringForAKey()
     {
         $this->assertSame('Bar', $this->object->alt('FOO', ''));
     }
 
-    /**
-     * @testdox  Verify that Text::alt() returns the correct string for a key with an alt
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::alt() returns the correct string for a key with an alt')]
     public function testAltReturnsTheCorrectStringForAKeyWithAlt()
     {
         $this->assertSame('Car', $this->object->alt('FOO', 'GOO'));
     }
 
-    /**
-     * @testdox  Verify that Text::alt() returns the correct string for a key with an alt and named parameters
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::alt() returns the correct string for a key with an alt and named parameters')]
     public function testAltReturnsTheCorrectStringForAKeyWithAltAndNamedParameters()
     {
         $this->assertSame('Green Car', $this->object->alt('FOO', 'BOO', ['%description%' => 'Green']));
     }
 
-    /**
-     * @testdox  Verify that Text::plural() returns the input key when no plural key is found
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::plural() returns the input key when no plural key is found')]
     public function testPluralReturnsInputKeyWhenNoParamsPassed()
     {
         $this->assertSame('BAR', $this->object->plural('BAR', 0));
     }
 
-    /**
-     * @testdox  Verify that Text::plural() returns the translated string when the pluralised key is found
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::plural() returns the translated string when the pluralised key is found')]
     public function testPluralReturnsTranslatedStringWhenPluralisedKeyFound()
     {
         $this->assertSame('3 Bars', $this->object->plural('BAR', 3));
     }
 
-    /**
-     * @testdox  Verify that Text::sprintf() returns the input key when no key is found
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::sprintf() returns the input key when no key is found')]
     public function testSprintfReturnsInputKeyWhenKeyNotFound()
     {
         $this->assertSame('BAR_NONE', $this->object->sprintf('BAR_NONE', 0));
     }
 
-    /**
-     * @testdox  Verify that Text::sprintf() returns the translated string when the specified key is found
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::sprintf() returns the translated string when the specified key is found')]
     public function testSprintfReturnsTranslatedStringWhenKeyFound()
     {
         $this->assertSame('I have 3 cars!', $this->object->sprintf('MANY_CARS', 3));
     }
 
-    /**
-     * @testdox  Verify that Text::printf() returns the input key when no key is found
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::printf() returns the input key when no key is found')]
     public function testPrintfReturnsEmptyStringWhenKeyNotFound()
     {
         ob_start();
@@ -301,17 +179,7 @@ class TextTest extends TestCase
         $this->assertSame('BAR_NONE', $return);
     }
 
-    /**
-     * @testdox  Verify that Text::printf() returns the translated string when the specified key is found
-     *
-     * @covers   Joomla\Language\Text
-     * @uses     Joomla\Language\Language
-     * @uses     Joomla\Language\LanguageFactory
-     * @uses     Joomla\Language\LanguageHelper
-     * @uses     Joomla\Language\MessageCatalogue
-     * @uses     Joomla\Language\ParserRegistry
-     * @uses     Joomla\Language\Parser\IniParser
-     */
+    #[TestDox('Verify that Text::printf() returns the translated string when the specified key is found')]
     public function testPrintfReturnsTranslatedStringWhenKeyFound()
     {
         ob_start();

--- a/tests/TransliterateTest.php
+++ b/tests/TransliterateTest.php
@@ -71,6 +71,6 @@ class TransliterateTest extends TestCase
     #[TestDox('Verify a UTF-8 string is transliterated correctly')]
     public function testVerifyAUTF8StringIsTransliteratedCorrectly($word, $result, $case)
     {
-        $this->assertEquals($result, $this->object->utf8_latin_to_ascii($word, $case));
+        $this->assertSame($result, $this->object->utf8_latin_to_ascii($word, $case));
     }
 }

--- a/tests/TransliterateTest.php
+++ b/tests/TransliterateTest.php
@@ -8,12 +8,15 @@
 namespace Joomla\Language\Tests;
 
 use Joomla\Language\Transliterate;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Transliterate.
  */
+#[CoversClass(Transliterate::class)]
 class TransliterateTest extends TestCase
 {
     /**
@@ -60,15 +63,12 @@ class TransliterateTest extends TestCase
     }
 
     /**
-     * @testdox  Verify a UTF-8 string is transliterated correctly
-     *
      * @param   string   $word    Word to transliterate
      * @param   string   $result  Expected test result
      * @param   integer  $case    Optionally specify upper or lower case. Default to 0 (both).
-     *
-     * @covers  \Joomla\Language\Transliterate
      */
     #[DataProvider('dataProvider')]
+    #[TestDox('Verify a UTF-8 string is transliterated correctly')]
     public function testVerifyAUTF8StringIsTransliteratedCorrectly($word, $result, $case)
     {
         $this->assertEquals($result, $this->object->utf8_latin_to_ascii($word, $case));

--- a/tests/stubs/StubLocalise.php
+++ b/tests/stubs/StubLocalise.php
@@ -10,8 +10,6 @@
 namespace Joomla\Language\Tests\stubs;
 
 use Joomla\Language\Localise\AbstractLocalise;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Joomla\Language\Localise\AbstractLocalise.


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

- missing migration from convert metadata doc-comments to attributes

### Testing Instructions

run `vendor/bin/phpunit --testdox`

### Documentation Changes Required

no